### PR TITLE
Configure models path via ENV variable

### DIFF
--- a/deepface/DeepFace.py
+++ b/deepface/DeepFace.py
@@ -817,4 +817,4 @@ def detectFace(img_path, detector_backend = 'opencv', enforce_detection = True, 
 #---------------------------
 #main
 
-functions.initializeFolder()
+functions.initialize_folder()

--- a/deepface/basemodels/ArcFace.py
+++ b/deepface/basemodels/ArcFace.py
@@ -10,6 +10,8 @@ import os
 from pathlib import Path
 import gdown
 
+from deepface.commons import functions
+
 #url = "https://drive.google.com/uc?id=1LVB3CdVejpmGHM28BpqqkbZP5hDEcdZY"
 
 def loadModel(url = 'https://github.com/serengil/deepface_models/releases/download/v1.0/arcface_weights.h5'):
@@ -26,7 +28,7 @@ def loadModel(url = 'https://github.com/serengil/deepface_models/releases/downlo
 	#---------------------------------------
 	#check the availability of pre-trained weights
 
-	home = str(Path.home())
+	home = functions.get_deepface_home()
 
 	file_name = "arcface_weights.h5"
 	output = home+'/.deepface/weights/'+file_name

--- a/deepface/basemodels/Boosting.py
+++ b/deepface/basemodels/Boosting.py
@@ -44,7 +44,7 @@ def build_gbm():
 	#this is not a must dependency
 	import lightgbm as lgb #lightgbm==2.3.1
 	
-	home = str(Path.home())
+	home = functions.get_deepface_home()
 	
 	if os.path.isfile(home+'/.deepface/weights/face-recognition-ensemble-model.txt') != True:
 		print("face-recognition-ensemble-model.txt will be downloaded...")

--- a/deepface/basemodels/DeepID.py
+++ b/deepface/basemodels/DeepID.py
@@ -7,6 +7,8 @@ from tensorflow import keras
 from tensorflow.keras.models import Model
 from tensorflow.keras.layers import Conv2D, Activation, Input, Add, MaxPooling2D, Flatten, Dense, Dropout
 
+from deepface.commons import functions
+
 #-------------------------------------
 
 #url = 'https://drive.google.com/uc?id=1uRLtBCTQQAvHJ_KVrdbRJiCKxU8m5q2J'
@@ -41,7 +43,7 @@ def loadModel(url = 'https://github.com/serengil/deepface_models/releases/downlo
 
 	#---------------------------------
 
-	home = str(Path.home())
+	home = functions.get_deepface_home()
 
 	if os.path.isfile(home+'/.deepface/weights/deepid_keras_weights.h5') != True:
 		print("deepid_keras_weights.h5 will be downloaded...")

--- a/deepface/basemodels/DlibResNet.py
+++ b/deepface/basemodels/DlibResNet.py
@@ -5,6 +5,8 @@ import gdown
 import numpy as np
 from pathlib import Path
 
+from deepface.commons import functions
+
 class DlibResNet:
 	
 	def __init__(self):
@@ -16,7 +18,7 @@ class DlibResNet:
 		
 		#---------------------
 		
-		home = str(Path.home())
+		home = functions.get_deepface_home()
 		weight_file = home+'/.deepface/weights/dlib_face_recognition_resnet_model_v1.dat'
 		
 		#---------------------

--- a/deepface/basemodels/Facenet.py
+++ b/deepface/basemodels/Facenet.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import gdown
 from functools import partial
 
+from deepface.commons import functions
+
 import tensorflow as tf
 tf_version = int(tf.__version__.split(".")[0])
 
@@ -555,7 +557,7 @@ def loadModel(url = 'https://github.com/serengil/deepface_models/releases/downlo
 
 	#-----------------------------------
 
-	home = str(Path.home())
+	home = functions.get_deepface_home()
 
 	if os.path.isfile(home+'/.deepface/weights/facenet_weights.h5') != True:
 		print("facenet_weights.h5 will be downloaded...")

--- a/deepface/basemodels/Facenet512.py
+++ b/deepface/basemodels/Facenet512.py
@@ -3,13 +3,15 @@ from pathlib import Path
 import os
 import gdown
 
+from deepface.commons import functions
+
 def loadModel(url = 'https://github.com/serengil/deepface_models/releases/download/v1.0/facenet512_weights.h5'):
 
     model = Facenet.InceptionResNetV2(dimension = 512)
 
     #-------------------------
 
-    home = str(Path.home())
+    home = functions.get_deepface_home()
 
     if os.path.isfile(home+'/.deepface/weights/facenet512_weights.h5') != True:
         print("facenet512_weights.h5 will be downloaded...")

--- a/deepface/basemodels/FbDeepFace.py
+++ b/deepface/basemodels/FbDeepFace.py
@@ -7,6 +7,8 @@ from tensorflow import keras
 from tensorflow.keras.models import Model, Sequential
 from tensorflow.keras.layers import Convolution2D, LocallyConnected2D, MaxPooling2D, Flatten, Dense, Dropout
 
+from deepface.commons import functions
+
 #-------------------------------------
 
 def loadModel(url = 'https://github.com/swghosh/DeepFace/releases/download/weights-vggface2-2d-aligned/VGGFace2_DeepFace_weights_val-0.9034.h5.zip'):
@@ -24,7 +26,7 @@ def loadModel(url = 'https://github.com/swghosh/DeepFace/releases/download/weigh
 	
 	#---------------------------------
 	
-	home = str(Path.home())
+	home = functions.get_deepface_home()
 	
 	if os.path.isfile(home+'/.deepface/weights/VGGFace2_DeepFace_weights_val-0.9034.h5') != True:
 		print("VGGFace2_DeepFace_weights_val-0.9034.h5 will be downloaded...")

--- a/deepface/basemodels/OpenFace.py
+++ b/deepface/basemodels/OpenFace.py
@@ -11,6 +11,8 @@ from tensorflow.keras.layers import MaxPooling2D, AveragePooling2D
 from tensorflow.keras.models import load_model
 from tensorflow.keras import backend as K
 
+from deepface.commons import functions
+
 #---------------------------------------
 
 #url = 'https://drive.google.com/uc?id=1LSe1YCV1x-BfNnfb7DFZTNpv_Q9jITxn'
@@ -232,7 +234,7 @@ def loadModel(url = 'https://github.com/serengil/deepface_models/releases/downlo
 	
 	#-----------------------------------
 
-	home = str(Path.home())
+	home = functions.get_deepface_home()
 
 	if os.path.isfile(home+'/.deepface/weights/openface_weights.h5') != True:
 		print("openface_weights.h5 will be downloaded...")

--- a/deepface/basemodels/VGGFace.py
+++ b/deepface/basemodels/VGGFace.py
@@ -2,6 +2,8 @@ import os
 from pathlib import Path
 import gdown
 
+from deepface.commons import functions
+
 import tensorflow as tf
 tf_version = int(tf.__version__.split(".")[0])
 
@@ -71,7 +73,7 @@ def loadModel(url = 'https://github.com/serengil/deepface_models/releases/downlo
 
 	#-----------------------------------
 
-	home = str(Path.home())
+	home = functions.get_deepface_home()
 	output = home+'/.deepface/weights/vgg_face_weights.h5'
 
 	if os.path.isfile(output) != True:

--- a/deepface/commons/functions.py
+++ b/deepface/commons/functions.py
@@ -44,16 +44,18 @@ def initialize_input(img1_path, img2_path = None):
 	return img_list, bulkProcess
 
 def initialize_folder():
-
-	home = str(Path.home())
+	home = get_deepface_home()
 
 	if not os.path.exists(home+"/.deepface"):
-		os.mkdir(home+"/.deepface")
-		print("Directory ",home,"/.deepface created")
+		os.makedirs(home+"/.deepface")
+		print("Directory ", home, "/.deepface created")
 
 	if not os.path.exists(home+"/.deepface/weights"):
-		os.mkdir(home+"/.deepface/weights")
-		print("Directory ",home,"/.deepface/weights created")
+		os.makedirs(home+"/.deepface/weights")
+		print("Directory ", home, "/.deepface/weights created")
+
+def get_deepface_home():
+	return str(os.getenv('DEEPFACE_HOME', default=Path.home()))
 
 def loadBase64Img(uri):
    encoded_data = uri.split(',')[1]

--- a/deepface/commons/functions.py
+++ b/deepface/commons/functions.py
@@ -43,7 +43,7 @@ def initialize_input(img1_path, img2_path = None):
 
 	return img_list, bulkProcess
 
-def initializeFolder():
+def initialize_folder():
 
 	home = str(Path.home())
 

--- a/deepface/detectors/DlibWrapper.py
+++ b/deepface/detectors/DlibWrapper.py
@@ -3,9 +3,11 @@ import gdown
 import bz2
 import os
 
+from deepface.commons import functions
+
 def build_model():
 
-	home = str(Path.home())
+	home = functions.get_deepface_home()
 
 	import dlib #this requirement is not a must that's why imported here
 

--- a/deepface/detectors/SsdWrapper.py
+++ b/deepface/detectors/SsdWrapper.py
@@ -5,10 +5,11 @@ import cv2
 import pandas as pd
 
 from deepface.detectors import OpenCvWrapper
+from deepface.commons import functions
 
 def build_model():
 
-	home = str(Path.home())
+	home = functions.get_deepface_home()
 
 	#model structure
 	if os.path.isfile(home+'/.deepface/weights/deploy.prototxt') != True:

--- a/deepface/extendedmodels/Age.py
+++ b/deepface/extendedmodels/Age.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import gdown
 import numpy as np
 
+from deepface.commons import functions
+
 import tensorflow as tf
 tf_version = int(tf.__version__.split(".")[0])
 
@@ -38,7 +40,7 @@ def loadModel(url = 'https://github.com/serengil/deepface_models/releases/downlo
 
 	#load weights
 
-	home = str(Path.home())
+	home = functions.get_deepface_home()
 
 	if os.path.isfile(home+'/.deepface/weights/age_model_weights.h5') != True:
 		print("age_model_weights.h5 will be downloaded...")

--- a/deepface/extendedmodels/Emotion.py
+++ b/deepface/extendedmodels/Emotion.py
@@ -3,6 +3,8 @@ import gdown
 from pathlib import Path
 import zipfile
 
+from deepface.commons import functions
+
 import tensorflow as tf
 tf_version = int(tf.__version__.split(".")[0])
 
@@ -49,7 +51,7 @@ def loadModel(url = 'https://github.com/serengil/deepface_models/releases/downlo
 
 	#----------------------------
 
-	home = str(Path.home())
+	home = functions.get_deepface_home()
 
 	if os.path.isfile(home+'/.deepface/weights/facial_expression_model_weights.h5') != True:
 		print("facial_expression_model_weights.h5 will be downloaded...")

--- a/deepface/extendedmodels/Gender.py
+++ b/deepface/extendedmodels/Gender.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import gdown
 import numpy as np
 
+from deepface.commons import functions
+
 import tensorflow as tf
 tf_version = int(tf.__version__.split(".")[0])
 
@@ -36,7 +38,7 @@ def loadModel(url = 'https://github.com/serengil/deepface_models/releases/downlo
 
 	#load weights
 
-	home = str(Path.home())
+	home = functions.get_deepface_home()
 
 	if os.path.isfile(home+'/.deepface/weights/gender_model_weights.h5') != True:
 		print("gender_model_weights.h5 will be downloaded...")

--- a/deepface/extendedmodels/Race.py
+++ b/deepface/extendedmodels/Race.py
@@ -6,6 +6,8 @@ import gdown
 import numpy as np
 import zipfile
 
+from deepface.commons import functions
+
 import tensorflow as tf
 tf_version = int(tf.__version__.split(".")[0])
 
@@ -38,7 +40,7 @@ def loadModel(url = 'https://github.com/serengil/deepface_models/releases/downlo
 
 	#load weights
 
-	home = str(Path.home())
+	home = functions.get_deepface_home()
 
 	if os.path.isfile(home+'/.deepface/weights/race_model_single_batch.h5') != True:
 		print("race_model_single_batch.h5 will be downloaded...")


### PR DESCRIPTION
Dear Sefik, thanks for this already great library!

This PR proposes to optionally set the path at which the `.deepface` directory will be created via the `DEEPFACE_HOME` env variable. The directory falls back to `Path.home()` if the ENV variable is unset.