### PR TITLE
Remove extra BGR2RGB call in RetinaFaceWrapper

### DIFF
--- a/deepface/detectors/RetinaFaceWrapper.py
+++ b/deepface/detectors/RetinaFaceWrapper.py
@@ -15,7 +15,8 @@ def detect_face(face_detector, img, align = True):
 
     resp = []
 
-    img_rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB) #retinaface expects RGB but OpenCV read BGR
+    # The BGR2RGB conversion will be done in the preprocessing step of retinaface.
+    # img_rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB) #retinaface expects RGB but OpenCV read BGR
 
     """
     face = None

--- a/deepface/detectors/RetinaFaceWrapper.py
+++ b/deepface/detectors/RetinaFaceWrapper.py
@@ -32,7 +32,7 @@ def detect_face(face_detector, img, align = True):
 
     #--------------------------
 
-    obj = RetinaFace.detect_faces(img_rgb, model = face_detector, threshold = 0.9)
+    obj = RetinaFace.detect_faces(img, model = face_detector, threshold = 0.9)
 
     if type(obj) == dict:
         for key in obj:


### PR DESCRIPTION
I suggest removing the extra BGR2RGB call.

While the RetinaFace model does expect RGB images, the corresponding conversion will be done in the RetinaFace preprocessing:
https://github.com/serengil/retinaface/blob/0c8d3ed8bd223c5753978a5e32549c25edff3316/retinaface/commons/preprocess.py#L45

The extra BGR2RGB call here will in fact make the final channel order wrong, because OpenCV does not know about the channel order, each call will simply swap the channels.

Thanks!