### PR TITLE
Enhanced cropping of detected faces using dlib

### DIFF
--- a/deepface/detectors/DlibWrapper.py
+++ b/deepface/detectors/DlibWrapper.py
@@ -55,7 +55,7 @@ def detect_face(detector, img, align = True):
 		for idx, d in enumerate(detections):
 			left = d.left(); right = d.right()
 			top = d.top(); bottom = d.bottom()
-			detected_face = img[top:bottom, left:right]
+			detected_face = img[max(0, top): min(bottom, img.shape[0]), max(0, left): min(right, img.shape[1])]
 			img_region = [left, top, right - left, bottom - top]
 
 			if align:


### PR DESCRIPTION
There are edge cases where the bounding box is partially outside the image window (that explains the fact that some coordinates of the bounding box in dlib have negative values). In these cases, cropping the detected face based on the box coordinates either fails or returns odd results.

So, instead of this command

detected_face = img[top:bottom, left:right]

we should get the detected face with the following command

detected_face = img[max(0, top): min(bottom, img_height), max(0, left): min(right, img_width)]