### PR TITLE
Added confidence to FaceDetector.detect_face and .detect_faces methods

### DIFF
--- a/deepface/commons/functions.py
+++ b/deepface/commons/functions.py
@@ -110,7 +110,7 @@ def detect_face(img, detector_backend = 'opencv', grayscale = False, enforce_det
 	face_detector = FaceDetector.build_model(detector_backend)
 
 	try:
-		detected_face, img_region = FaceDetector.detect_face(face_detector, detector_backend, img, align)
+		detected_face, img_region, _ = FaceDetector.detect_face(face_detector, detector_backend, img, align)
 	except: #if detected face shape is (0, 0) and alignment cannot be performed, this block will be run
 		detected_face = None
 

--- a/deepface/commons/realtime.py
+++ b/deepface/commons/realtime.py
@@ -151,7 +151,7 @@ def analysis(db_path, model_name = 'VGG-Face', detector_backend = 'opencv', dist
 
 		detected_faces = []
 		face_index = 0
-		for face, (x, y, w, h) in faces:
+		for face, (x, y, w, h), _ in faces:
 			if w > 130: #discard small detected faces
 
 				face_detected = True

--- a/deepface/detectors/DlibWrapper.py
+++ b/deepface/detectors/DlibWrapper.py
@@ -46,9 +46,12 @@ def detect_face(detector, img, align = True):
 
 	detected_face = None
 	img_region = [0, 0, img.shape[0], img.shape[1]]
+	confidence = None
 
 	face_detector = detector["face_detector"]
-	detections = face_detector(img, 1)
+
+	#note that, by design, dlib's fhog face detector scores are >0 but not capped at 1
+	detections, scores, _ = face_detector.run(img, 1)
 
 	if len(detections) > 0:
 
@@ -60,12 +63,13 @@ def detect_face(detector, img, align = True):
 			detected_face = img[max(0, top): min(bottom, img.shape[0]), max(0, left): min(right, img.shape[1])]
 			
 			img_region = [left, top, right - left, bottom - top]
+			confidence = scores[idx]
 
 			if align:
 				img_shape = sp(img, detections[idx])
 				detected_face = dlib.get_face_chip(img, img_shape, size = detected_face.shape[0])
 
-			resp.append((detected_face, img_region))
+			resp.append((detected_face, img_region, confidence))
 
 
 	return resp

--- a/deepface/detectors/FaceDetector.py
+++ b/deepface/detectors/FaceDetector.py
@@ -14,7 +14,7 @@ def build_model(detector_backend):
         'dlib': DlibWrapper.build_model,
         'mtcnn': MtcnnWrapper.build_model,
         'retinaface': RetinaFaceWrapper.build_model,
-	'mediapipe': MediapipeWrapper.build_model
+	    'mediapipe': MediapipeWrapper.build_model
     }
 
     if not "face_detector_obj" in globals():
@@ -37,12 +37,13 @@ def detect_face(face_detector, detector_backend, img, align = True):
     obj = detect_faces(face_detector, detector_backend, img, align)
 
     if len(obj) > 0:
-        face, region = obj[0] #discard multiple faces
+        face, region, confidence = obj[0] #discard multiple faces
     else: #len(obj) == 0
         face = None
         region = [0, 0, img.shape[0], img.shape[1]]
+        confidence = None
 
-    return face, region
+    return face, region, confidence
 
 def detect_faces(face_detector, detector_backend, img, align = True):
 
@@ -52,14 +53,14 @@ def detect_faces(face_detector, detector_backend, img, align = True):
         'dlib': DlibWrapper.detect_face,
         'mtcnn': MtcnnWrapper.detect_face,
         'retinaface': RetinaFaceWrapper.detect_face,
-	'mediapipe': MediapipeWrapper.detect_face
+	    'mediapipe': MediapipeWrapper.detect_face
     }
 
     detect_face = backends.get(detector_backend)
 
     if detect_face:
         obj = detect_face(face_detector, img, align)
-        #obj stores list of detected_face and region pair
+        #obj stores list of (detected_face, region, confidence)
 
         return obj
     else:

--- a/deepface/detectors/MediapipeWrapper.py
+++ b/deepface/detectors/MediapipeWrapper.py
@@ -19,8 +19,8 @@ def detect_face(face_detector, img, align = True):
     
     if results.detections:
         for detection in results.detections:
-            
-            confidence = detection.score
+
+            confidence, = detection.score
             
             bounding_box = detection.location_data.relative_bounding_box
             landmarks = detection.location_data.relative_keypoints
@@ -44,6 +44,6 @@ def detect_face(face_detector, img, align = True):
                 if align:
                     detected_face = FaceDetector.alignment_procedure(detected_face, left_eye, right_eye)
                     
-                resp.append((detected_face,img_region))
+                resp.append((detected_face, img_region, confidence))
                 
     return resp

--- a/deepface/detectors/MtcnnWrapper.py
+++ b/deepface/detectors/MtcnnWrapper.py
@@ -12,6 +12,7 @@ def detect_face(face_detector, img, align = True):
 
 	detected_face = None
 	img_region = [0, 0, img.shape[0], img.shape[1]]
+	confidence = None
 
 	img_rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB) #mtcnn expects RGB but OpenCV read BGR
 	detections = face_detector.detect_faces(img_rgb)
@@ -22,6 +23,7 @@ def detect_face(face_detector, img, align = True):
 			x, y, w, h = detection["box"]
 			detected_face = img[int(y):int(y+h), int(x):int(x+w)]
 			img_region = [x, y, w, h]
+			confidence = detection["confidence"]
 
 			if align:
 				keypoints = detection["keypoints"]
@@ -29,6 +31,6 @@ def detect_face(face_detector, img, align = True):
 				right_eye = keypoints["right_eye"]
 				detected_face = FaceDetector.alignment_procedure(detected_face, left_eye, right_eye)
 
-			resp.append((detected_face, img_region))
+			resp.append((detected_face, img_region, confidence))
 
 	return resp

--- a/deepface/detectors/OpenCvWrapper.py
+++ b/deepface/detectors/OpenCvWrapper.py
@@ -41,17 +41,20 @@ def detect_face(detector, img, align = True):
 
 	detected_face = None
 	img_region = [0, 0, img.shape[0], img.shape[1]]
+	confidence = None
 
 	faces = []
 	try:
 		#faces = detector["face_detector"].detectMultiScale(img, 1.3, 5)
-		faces = detector["face_detector"].detectMultiScale(img, 1.1, 10)
+		
+		#note that, by design, opencv's haarcascade scores are >0 but not capped at 1
+		faces, _, scores = detector["face_detector"].detectMultiScale3(img, 1.1, 10, outputRejectLevels = True)
 	except:
 		pass
 
 	if len(faces) > 0:
 
-		for x,y,w,h in faces:
+		for (x,y,w,h), confidence in zip(faces, scores):
 			detected_face = img[int(y):int(y+h), int(x):int(x+w)]
 
 			if align:
@@ -59,7 +62,7 @@ def detect_face(detector, img, align = True):
 
 			img_region = [x, y, w, h]
 
-			resp.append((detected_face, img_region))
+			resp.append((detected_face, img_region, confidence))
 
 	return resp
 

--- a/deepface/detectors/RetinaFaceWrapper.py
+++ b/deepface/detectors/RetinaFaceWrapper.py
@@ -44,6 +44,7 @@ def detect_face(face_detector, img, align = True):
             x = facial_area[0]
             w = facial_area[2] - x
             img_region = [x, y, w, h]
+            confidence = identity["score"]
 
             #detected_face = img[int(y):int(y+h), int(x):int(x+w)] #opencv
             detected_face = img[facial_area[1]: facial_area[3], facial_area[0]: facial_area[2]]
@@ -58,6 +59,6 @@ def detect_face(face_detector, img, align = True):
 
                 detected_face = postprocess.alignment_procedure(detected_face, right_eye, left_eye, nose)
 
-            resp.append((detected_face, img_region))
+            resp.append((detected_face, img_region, confidence))
 
     return resp

--- a/deepface/detectors/SsdWrapper.py
+++ b/deepface/detectors/SsdWrapper.py
@@ -52,6 +52,7 @@ def detect_face(detector, img, align = True):
 
 	detected_face = None
 	img_region = [0, 0, img.shape[0], img.shape[1]]
+	confidence = None
 
 	ssd_labels = ["img_id", "is_face", "confidence", "left", "top", "right", "bottom"]
 
@@ -93,10 +94,11 @@ def detect_face(detector, img, align = True):
 
 			detected_face = base_img[int(top*aspect_ratio_y):int(bottom*aspect_ratio_y), int(left*aspect_ratio_x):int(right*aspect_ratio_x)]
 			img_region = [int(left*aspect_ratio_x), int(top*aspect_ratio_y), int(right*aspect_ratio_x) - int(left*aspect_ratio_x), int(bottom*aspect_ratio_y) - int(top*aspect_ratio_y)]
+			confidence = instance["confidence"]
 
 			if align:
 				detected_face = OpenCvWrapper.align_face(detector["eye_detector"], detected_face)
 
-			resp.append((detected_face, img_region))
+			resp.append((detected_face, img_region, confidence))
 
 	return resp


### PR DESCRIPTION
Good morning,
I have implemented the return of confidence scores from the FaceDetector.detect_face and FaceDetector.detect_faces methods as a third parameter: (cropped_face, region, confidence).

I have also adapted other functions in this package using these methods such that they take into account the change.

In a documentation for FaceDetector exists, this may be a worthwhile note:
- MTCNN, Retinanet, Mediapipe and SSD have confidences in range [0, 1]
- OpenCV and DLib have confidence >=0 (not capped at 1, by design of the detectors)
- If a detector backend does not support returning the scores (not the case for now but may be in the future) it will return None as confidence score.

Finally, please note that:
- SSD already automatically discards faces with confidence <0.9
- RetinaFace already automatically discards faces with confidence <0.9
- RetinaFace already automatically discards faces with confidence <0.7
It may make sense, in order to allow end user to select its own detection thresholds, to decrease these default thresholds or adding a parameter to FaceDetector.detect_faces

Thank you for this powerful package.