### PR TITLE
Fixed minor bug: all regions now are (left, top, width, height)

### DIFF
--- a/deepface/commons/functions.py
+++ b/deepface/commons/functions.py
@@ -95,7 +95,7 @@ def load_image(img):
 
 def detect_face(img, detector_backend = 'opencv', grayscale = False, enforce_detection = True, align = True):
 
-	img_region = [0, 0, img.shape[0], img.shape[1]]
+	img_region = [0, 0, img.shape[1], img.shape[0]]
 
 	#----------------------------------------------
 	#people would like to skip detection and alignment if they already have pre-processed images

--- a/deepface/detectors/DlibWrapper.py
+++ b/deepface/detectors/DlibWrapper.py
@@ -45,7 +45,7 @@ def detect_face(detector, img, align = True):
 	sp = detector["sp"]
 
 	detected_face = None
-	img_region = [0, 0, img.shape[0], img.shape[1]]
+	img_region = [0, 0, img.shape[1], img.shape[0]]
 
 	face_detector = detector["face_detector"]
 	detections = face_detector(img, 1)

--- a/deepface/detectors/FaceDetector.py
+++ b/deepface/detectors/FaceDetector.py
@@ -40,7 +40,7 @@ def detect_face(face_detector, detector_backend, img, align = True):
         face, region = obj[0] #discard multiple faces
     else: #len(obj) == 0
         face = None
-        region = [0, 0, img.shape[0], img.shape[1]]
+        region = [0, 0, img.shape[1], img.shape[0]]
 
     return face, region
 

--- a/deepface/detectors/MtcnnWrapper.py
+++ b/deepface/detectors/MtcnnWrapper.py
@@ -11,7 +11,7 @@ def detect_face(face_detector, img, align = True):
 	resp = []
 
 	detected_face = None
-	img_region = [0, 0, img.shape[0], img.shape[1]]
+	img_region = [0, 0, img.shape[1], img.shape[0]]
 
 	img_rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB) #mtcnn expects RGB but OpenCV read BGR
 	detections = face_detector.detect_faces(img_rgb)

--- a/deepface/detectors/OpenCvWrapper.py
+++ b/deepface/detectors/OpenCvWrapper.py
@@ -40,7 +40,7 @@ def detect_face(detector, img, align = True):
 	resp = []
 
 	detected_face = None
-	img_region = [0, 0, img.shape[0], img.shape[1]]
+	img_region = [0, 0, img.shape[1], img.shape[0]]
 
 	faces = []
 	try:

--- a/deepface/detectors/RetinaFaceWrapper.py
+++ b/deepface/detectors/RetinaFaceWrapper.py
@@ -20,7 +20,7 @@ def detect_face(face_detector, img, align = True):
 
     """
     face = None
-    img_region = [0, 0, img.shape[0], img.shape[1]] #Really?
+    img_region = [0, 0, img.shape[1], img.shape[0]] #Really?
 
     faces = RetinaFace.extract_faces(img_rgb, model = face_detector, align = align)
 

--- a/deepface/detectors/SsdWrapper.py
+++ b/deepface/detectors/SsdWrapper.py
@@ -51,7 +51,7 @@ def detect_face(detector, img, align = True):
 	resp = []
 
 	detected_face = None
-	img_region = [0, 0, img.shape[0], img.shape[1]]
+	img_region = [0, 0, img.shape[1], img.shape[0]]
 
 	ssd_labels = ["img_id", "is_face", "confidence", "left", "top", "right", "bottom"]
 


### PR DESCRIPTION
Good Morning,
I have noticed that when the local variable img_region in .detect_faces methods are initialized as:
`img_region = [0, 0, img.shape[0], img.shape[1]`

This breaks the convention of the rest of the region variables in the package, which follow: (left, top, width, height).

I have therefore changed these for consistency. It should be noted that this will have absolutely zero impact on the functionality of the functions, as this initialized variable is always unused in the detector wrappers. The only case in which this can have an impact is when functions.detect_faces is used with "skip" detector_backend.

