### PR TITLE
RetinaFace: unpack detection tuple to get detection dict

### DIFF
--- a/deepface/detectors/RetinaFaceWrapper.py
+++ b/deepface/detectors/RetinaFaceWrapper.py
@@ -19,7 +19,8 @@ def detect_face(face_detector, img, align=True):
     obj = RetinaFace.detect_faces(img, model=face_detector, threshold=0.9)
 
     if isinstance(obj, dict):
-        for identity in obj.items():
+        for item in obj.items():
+            identity = item[1]
             facial_area = identity["facial_area"]
 
             y = facial_area[1]


### PR DESCRIPTION
Hi, 
cool project, I found and fixed a minor bug.
The RetinaFace detector returns a tuple, such as ('face_1', {'score': 0.9990754127502441, 'facial_area': [491, 315, 530, 351], 'landmarks': {'right_eye': [499.70813, 336.54434], 'left_eye': [504.4929, 332.72052], 'nose': [503.60852, 343.8499], 'mouth_right': [515.26355, 346.87634], 'mouth_left': [516.86755, 343.4794]}})
Therefore, the actual detection dict is element 1 of this tuple.