### PR TITLE
Add Face Confidence to Deepface.represent()

### DIFF
--- a/deepface/DeepFace.py
+++ b/deepface/DeepFace.py
@@ -669,7 +669,7 @@ def represent(
         img_objs = [(img, img_region, 0)]
     # ---------------------------------
 
-    for img, region, _ in img_objs:
+    for img, region, confidence in img_objs:
         # custom normalization
         img = functions.normalize_input(img=img, normalization=normalization)
 
@@ -684,6 +684,7 @@ def represent(
         resp_obj = {}
         resp_obj["embedding"] = embedding
         resp_obj["facial_area"] = region
+        resp_obj["face_confidence"] = confidence
         resp_objs.append(resp_obj)
 
     return resp_objs


### PR DESCRIPTION
For my use case, I need to be able to filter representation embeddings by the face detection confidence. In some cases, detectors are giving false positives, so I need to be able to tweak the face confidence threshold in my analysis. With the current implementation, I would have to do face detection and face representation in separate steps to get the confidence.