### PR TITLE
Add non-default option to include image detection in output of DeepFace.represent().

### DIFF
--- a/deepface/DeepFace.py
+++ b/deepface/DeepFace.py
@@ -645,6 +645,7 @@ def represent(
     # we have run pre-process in verification. so, this can be skipped if it is coming from verify.
     if target_size == "auto":
         target_size = functions.find_target_size(model_name=model_name)
+     print('Target size:', target_size)
         
     if detector_backend != "skip":
         img_objs = functions.extract_faces(

--- a/deepface/DeepFace.py
+++ b/deepface/DeepFace.py
@@ -602,7 +602,6 @@ def represent(
     img_path,
     model_name="VGG-Face",
     enforce_detection=True,
-    target_size="auto",
     detector_backend="opencv",
     align=True,
     include_image_in_response=False,
@@ -643,9 +642,7 @@ def represent(
 
     # ---------------------------------
     # we have run pre-process in verification. so, this can be skipped if it is coming from verify.
-    if target_size == "auto":
-        target_size = functions.find_target_size(model_name=model_name)
-     print('Target size:', target_size)
+    target_size = functions.find_target_size(model_name=model_name)
         
     if detector_backend != "skip":
         img_objs = functions.extract_faces(

--- a/deepface/DeepFace.py
+++ b/deepface/DeepFace.py
@@ -602,6 +602,7 @@ def represent(
     img_path,
     model_name="VGG-Face",
     enforce_detection=True,
+    target_size="auto",
     detector_backend="opencv",
     align=True,
     include_image_in_response=False,
@@ -642,7 +643,9 @@ def represent(
 
     # ---------------------------------
     # we have run pre-process in verification. so, this can be skipped if it is coming from verify.
-    target_size = functions.find_target_size(model_name=model_name)
+    if target_size == "auto":
+        target_size = functions.find_target_size(model_name=model_name)
+        
     if detector_backend != "skip":
         img_objs = functions.extract_faces(
             img=img_path,

--- a/deepface/DeepFace.py
+++ b/deepface/DeepFace.py
@@ -604,6 +604,7 @@ def represent(
     enforce_detection=True,
     detector_backend="opencv",
     align=True,
+    include_image_in_response=False,
     normalization="base",
 ):
 
@@ -671,17 +672,19 @@ def represent(
 
     for img, region, confidence in img_objs:
         # custom normalization
-        img = functions.normalize_input(img=img, normalization=normalization)
+        normalized_img = functions.normalize_input(img=img, normalization=normalization)
 
         # represent
         if "keras" in str(type(model)):
             # new tf versions show progress bar and it is annoying
-            embedding = model.predict(img, verbose=0)[0].tolist()
+            embedding = model.predict(normalized_img, verbose=0)[0].tolist()
         else:
             # SFace and Dlib are not keras models and no verbose arguments
-            embedding = model.predict(img)[0].tolist()
+            embedding = model.predict(normalized_img)[0].tolist()
 
         resp_obj = {}
+        if include_image_in_response:
+            response_obj['face_img'] = img
         resp_obj["embedding"] = embedding
         resp_obj["facial_area"] = region
         resp_obj["face_confidence"] = confidence

--- a/deepface/DeepFace.py
+++ b/deepface/DeepFace.py
@@ -684,7 +684,7 @@ def represent(
 
         resp_obj = {}
         if include_image_in_response:
-            response_obj['face_img'] = img
+            resp_obj['face_img'] = img
         resp_obj["embedding"] = embedding
         resp_obj["facial_area"] = region
         resp_obj["face_confidence"] = confidence


### PR DESCRIPTION
My use case:  I run detections first (via DeepFace.represent()), and then later use the detections on DeepFace.analyze(). I want the option to include the detection image in the response so I don't have to re-do the detection in analyze().