### PR TITLE
Fix print formatting and grammar errors inside of the find function.

### DIFF
--- a/deepface/DeepFace.py
+++ b/deepface/DeepFace.py
@@ -460,7 +460,7 @@ def find(
             representations = pickle.load(f)
 
         if not silent:
-            print("There are ", len(representations), " representations found in ", file_name)
+            print("There are", len(representations), "representations found in", file_name)
 
     else:  # create representation.pkl from scratch
         employees = []
@@ -477,7 +477,7 @@ def find(
 
         if len(employees) == 0:
             raise ValueError(
-                "There is no image in ",
+                "There are no image in ",
                 db_path,
                 " folder! Validate .jpg or .png files exist in this path.",
             )


### PR DESCRIPTION
# This pull request fixes two small formatting/grammar errors.

### first one is [here](https://github.com/serengil/deepface/blob/master/deepface/DeepFace.py#L463)
```py
print("There are ", len(representations), " representations found in ", file_name)
```
when we call print, the default separator for arguments is `" "`, so including spaces around the `len(representation)` is not really required.

this would make more sense and it would also print better:
```py
print("There are", len(representations), "representations found in", file_name)
```

in the end we will have:
```py
>>> There are N representations found in {file_name}
>>> # instead of
>>> There are  N  representations found in  {file_name}
```

### second was a grammar mistake [here](https://github.com/serengil/deepface/blob/master/deepface/DeepFace.py#L480)
```py
if len(employees) == 0:
    raise ValueError(
        "There is no image in ",
        db_path,
        " folder! Validate .jpg or .png files exist in this path.",
    )
```

this should be changed to 
```py
if len(employees) == 0:
    raise ValueError(
        "There are no images in ",
        db_path,
        " folder! Validate .jpg or .png files exist in this path.",
    )
```