### PR TITLE
Correct laterality of the eyes landmarks ("close" #741)

### DIFF
--- a/deepface/detectors/MediapipeWrapper.py
+++ b/deepface/detectors/MediapipeWrapper.py
@@ -19,10 +19,11 @@ def detect_face(face_detector, img, align=True):
 
     results = face_detector.process(img)
 
-    # if no face have been detected, return an empty list
+    # If no face has been detected, return an empty list
     if results.detections is None:
         return resp
 
+    # Extract the bounding box, the landmarks and the confidence score
     for detection in results.detections:
         (confidence,) = detection.score
 
@@ -34,6 +35,7 @@ def detect_face(face_detector, img, align=True):
         y = int(bounding_box.ymin * img_height)
         h = int(bounding_box.height * img_height)
 
+        # Extract landmarks
         left_eye = (int(landmarks[0].x * img_width), int(landmarks[0].y * img_height))
         right_eye = (int(landmarks[1].x * img_width), int(landmarks[1].y * img_height))
         # nose = (int(landmarks[2].x * img_width), int(landmarks[2].y * img_height))

--- a/deepface/detectors/MediapipeWrapper.py
+++ b/deepface/detectors/MediapipeWrapper.py
@@ -19,35 +19,31 @@ def detect_face(face_detector, img, align=True):
 
     results = face_detector.process(img)
 
-    if results.detections:
-        for detection in results.detections:
+    for detection in results.detections:
+        (confidence,) = detection.score
 
-            (confidence,) = detection.score
+        bounding_box = detection.location_data.relative_bounding_box
+        landmarks = detection.location_data.relative_keypoints
 
-            bounding_box = detection.location_data.relative_bounding_box
-            landmarks = detection.location_data.relative_keypoints
+        x = int(bounding_box.xmin * img_width)
+        w = int(bounding_box.width * img_width)
+        y = int(bounding_box.ymin * img_height)
+        h = int(bounding_box.height * img_height)
 
-            x = int(bounding_box.xmin * img_width)
-            w = int(bounding_box.width * img_width)
-            y = int(bounding_box.ymin * img_height)
-            h = int(bounding_box.height * img_height)
+        left_eye = (int(landmarks[0].x * img_width), int(landmarks[0].y * img_height))
+        right_eye = (int(landmarks[1].x * img_width), int(landmarks[1].y * img_height))
+        # nose = (int(landmarks[2].x * img_width), int(landmarks[2].y * img_height))
+        # mouth = (int(landmarks[3].x * img_width), int(landmarks[3].y * img_height))
+        # right_ear = (int(landmarks[4].x * img_width), int(landmarks[4].y * img_height))
+        # left_ear = (int(landmarks[5].x * img_width), int(landmarks[5].y * img_height))
 
-            right_eye = (int(landmarks[0].x * img_width), int(landmarks[0].y * img_height))
-            left_eye = (int(landmarks[1].x * img_width), int(landmarks[1].y * img_height))
-            # nose = (int(landmarks[2].x * img_width), int(landmarks[2].y * img_height))
-            # mouth = (int(landmarks[3].x * img_width), int(landmarks[3].y * img_height))
-            # right_ear = (int(landmarks[4].x * img_width), int(landmarks[4].y * img_height))
-            # left_ear = (int(landmarks[5].x * img_width), int(landmarks[5].y * img_height))
+        if x > 0 and y > 0:
+            detected_face = img[y : y + h, x : x + w]
+            img_region = [x, y, w, h]
 
-            if x > 0 and y > 0:
-                detected_face = img[y : y + h, x : x + w]
-                img_region = [x, y, w, h]
+            if align:
+                detected_face = FaceDetector.alignment_procedure(detected_face, left_eye, right_eye)
 
-                if align:
-                    detected_face = FaceDetector.alignment_procedure(
-                        detected_face, left_eye, right_eye
-                    )
-
-                resp.append((detected_face, img_region, confidence))
+            resp.append((detected_face, img_region, confidence))
 
     return resp

--- a/deepface/detectors/MediapipeWrapper.py
+++ b/deepface/detectors/MediapipeWrapper.py
@@ -19,6 +19,10 @@ def detect_face(face_detector, img, align=True):
 
     results = face_detector.process(img)
 
+    # if no face have been detected, return an empty list
+    if results.detections is None:
+        return resp
+
     for detection in results.detections:
         (confidence,) = detection.score
 


### PR DESCRIPTION
Hi,

In https://github.com/serengil/deepface/issues/741, I noticed an error on the alignment. After further investigation, I noticed the error was in the mediapipe's wrapper. The eyes landmarks are permuted. There is head for improvement in other models (at least the one able to detect faced at any angle), like using a third poind (nose, mouth, etc.) to correctly realized the rotation.

Regards,
Vincent