### PR TITLE
Fix potential bug in OpenCvWrapper

### DIFF
--- a/deepface/detectors/OpenCvWrapper.py
+++ b/deepface/detectors/OpenCvWrapper.py
@@ -44,7 +44,9 @@ def detect_face(detector, img, align=True):
     detected_face = None
     img_region = [0, 0, img.shape[1], img.shape[0]]
 
+    # Initialize faces and scores to empty lists
     faces = []
+    scores = []
     try:
         # faces = detector["face_detector"].detectMultiScale(img, 1.3, 5)
 
@@ -52,19 +54,25 @@ def detect_face(detector, img, align=True):
         faces, _, scores = detector["face_detector"].detectMultiScale3(
             img, 1.1, 10, outputRejectLevels=True
         )
-    except:
-        pass
 
-    if len(faces) > 0:
-        for (x, y, w, h), confidence in zip(faces, scores):
-            detected_face = img[int(y) : int(y + h), int(x) : int(x + w)]
+    # except alone is too broad and will catch keyboard interrupts
+    # Exception should be changed to something more specific in the future
+    except Exception:  # pylint: disable=broad-except
+        import traceback
 
-            if align:
-                detected_face = align_face(detector["eye_detector"], detected_face)
+        print(traceback.format_exc())
 
-            img_region = [x, y, w, h]
+    # For each face and associated score, append face,
+    # bounding box, and score to resp
+    for (x, y, w, h), confidence in zip(faces, scores):
+        detected_face = img[int(y) : int(y + h), int(x) : int(x + w)]
 
-            resp.append((detected_face, img_region, confidence))
+        if align:
+            detected_face = align_face(detector["eye_detector"], detected_face)
+
+        img_region = [x, y, w, h]
+
+        resp.append((detected_face, img_region, confidence))
 
     return resp
 


### PR DESCRIPTION
Hello,

Here are some change to prevent some bug in `OpenCvWrapper.py`:

1. `score` is being declared in a `try:except:` block, thus it might not exist and raise an error later on.
2. No exception is specified in the `try:except:` block, which means the keyboard interrupt may be ignored.
3. Last but not least, checking for the size of the `faces` list before using it in a for loop is probably useless.

Best,
Vincent