### PR TITLE
change model.predict() to model(), notably improve memory leak (issue #697)

### DIFF
--- a/deepface/DeepFace.py
+++ b/deepface/DeepFace.py
@@ -693,7 +693,7 @@ def represent(
         # represent
         if "keras" in str(type(model)):
             # new tf versions show progress bar and it is annoying
-            embedding = model.predict(img, verbose=0)[0].tolist()
+            embedding = model(img, training=False).numpy()[0].tolist()
         else:
             # SFace and Dlib are not keras models and no verbose arguments
             embedding = model.predict(img)[0].tolist()


### PR DESCRIPTION
To help improve #697, I use `model()` replace `model.predict()` and get notably improvement, which aviod generates a data generator in  `model.predict()`.

In my case, for a 1000 times loop, the memory increment is about 50 MiB. it seems that `DeepFace.represent()` now is capable of 100k loop for most use.