### PR TITLE
Include detected face confidence

### DIFF
--- a/deepface/DeepFace.py
+++ b/deepface/DeepFace.py
@@ -264,6 +264,7 @@ def analyze(
                     {
                             "region": {'x': 230, 'y': 120, 'w': 36, 'h': 45},
                             "age": 28.66,
+                            'face_confidence': 0.9993908405303955,
                             "dominant_gender": "Woman",
                             "gender": {
                                     'Woman': 99.99407529830933,
@@ -335,7 +336,7 @@ def analyze(
         align=align,
     )
 
-    for img_content, img_region, _ in img_objs:
+    for img_content, img_region, img_confidence in img_objs:
         if img_content.shape[0] > 0 and img_content.shape[1] > 0:
             obj = {}
             # facial attribute analysis
@@ -390,6 +391,8 @@ def analyze(
                 # -----------------------------
                 # mention facial areas
                 obj["region"] = img_region
+                # include image confidence
+                obj["face_confidence"] = img_confidence
 
             resp_objects.append(obj)
 


### PR DESCRIPTION
I need to be able to filter response by confidence of the detected face/faces

I have a selfie image containing one person but I got 2 responses using mtcnn as backend
[{'age': 29,
  'region': {'x': 305, 'y': 457, 'w': 1036, 'h': 1378},
 {'age': 32,
  'region': {'x': 287, 'y': 844, 'w': 44, 'h': 52},]
  
It will be easier to identify false positives if the confidence of the face detected is returned as well

[{'age': 29,
  'region': {'x': 305, 'y': 457, 'w': 1036, 'h': 1378},
  'face_confidence': 0.9993908405303955},
 {'age': 32,
  'region': {'x': 287, 'y': 844, 'w': 44, 'h': 52},
  'face_confidence': 0.7173819541931152}]