### PR TITLE
include faster implementation of mtcnn

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Age model got ± 4.65 MAE; gender model got 97.44% accuracy, 96.29% precision an
 
 **Face Detectors** - [`Demo`](https://youtu.be/GZ2p2hj2H5k)
 
-Face detection and alignment are important early stages of a modern face recognition pipeline. Experiments show that just alignment increases the face recognition accuracy almost 1%. [`OpenCV`](https://sefiks.com/2020/02/23/face-alignment-for-face-recognition-in-python-within-opencv/), [`SSD`](https://sefiks.com/2020/08/25/deep-face-detection-with-opencv-in-python/), [`Dlib`](https://sefiks.com/2020/07/11/face-recognition-with-dlib-in-python/),  [`MTCNN`](https://sefiks.com/2020/09/09/deep-face-detection-with-mtcnn-in-python/), [`RetinaFace`](https://sefiks.com/2021/04/27/deep-face-detection-with-retinaface-in-python/), [`MediaPipe`](https://sefiks.com/2022/01/14/deep-face-detection-with-mediapipe/), [`YOLOv8 Face`](https://github.com/derronqi/yolov8-face) and [`YuNet`](https://github.com/ShiqiYu/libfacedetection) detectors are wrapped in deepface.
+Face detection and alignment are important early stages of a modern face recognition pipeline. Experiments show that just alignment increases the face recognition accuracy almost 1%. [`OpenCV`](https://sefiks.com/2020/02/23/face-alignment-for-face-recognition-in-python-within-opencv/), [`SSD`](https://sefiks.com/2020/08/25/deep-face-detection-with-opencv-in-python/), [`Dlib`](https://sefiks.com/2020/07/11/face-recognition-with-dlib-in-python/),  [`MTCNN`](https://sefiks.com/2020/09/09/deep-face-detection-with-mtcnn-in-python/), [`Faster MTCNN`](https://github.com/timesler/facenet-pytorch), [`RetinaFace`](https://sefiks.com/2021/04/27/deep-face-detection-with-retinaface-in-python/), [`MediaPipe`](https://sefiks.com/2022/01/14/deep-face-detection-with-mediapipe/), [`YOLOv8 Face`](https://github.com/derronqi/yolov8-face) and [`YuNet`](https://github.com/ShiqiYu/libfacedetection) detectors are wrapped in deepface.
 
 <p align="center"><img src="https://raw.githubusercontent.com/serengil/deepface/master/icon/detector-portfolio-v5.jpg" width="95%" height="95%"></p>
 
@@ -209,6 +209,7 @@ backends = [
   'mediapipe',
   'yolov8',
   'yunet',
+  'fastmtcnn',
 ]
 
 #face verification

--- a/deepface/detectors/FaceDetector.py
+++ b/deepface/detectors/FaceDetector.py
@@ -11,6 +11,7 @@ from deepface.detectors import (
     MediapipeWrapper,
     YoloWrapper,
     YunetWrapper,
+    FastMtcnnWrapper,
 )
 
 
@@ -26,6 +27,7 @@ def build_model(detector_backend):
         "mediapipe": MediapipeWrapper.build_model,
         "yolov8": YoloWrapper.build_model,
         "yunet": YunetWrapper.build_model,
+        "fastmtcnn": FastMtcnnWrapper.build_model,
     }
 
     if not "face_detector_obj" in globals():
@@ -70,6 +72,7 @@ def detect_faces(face_detector, detector_backend, img, align=True):
         "mediapipe": MediapipeWrapper.detect_face,
         "yolov8": YoloWrapper.detect_face,
         "yunet": YunetWrapper.detect_face,
+        "fastmtcnn": FastMtcnnWrapper.detect_face,
     }
 
     detect_face_fn = backends.get(detector_backend)

--- a/deepface/detectors/FastMtcnnWrapper.py
+++ b/deepface/detectors/FastMtcnnWrapper.py
@@ -6,7 +6,11 @@ from deepface.detectors import FaceDetector
 
 def build_model():
     # Optional dependency
-    from facenet_pytorch import MTCNN as fast_mtcnn
+    try:
+        from facenet_pytorch import MTCNN as fast_mtcnn
+    except ModuleNotFoundError:
+        print("This is an optional detector, ensure the library is installed. \
+              Please install using 'pip install facenet-pytorch' ")
 
 
     face_detector = fast_mtcnn(image_size=160,

--- a/deepface/detectors/FastMtcnnWrapper.py
+++ b/deepface/detectors/FastMtcnnWrapper.py
@@ -12,7 +12,8 @@ def build_model():
     face_detector = fast_mtcnn(image_size=160,
               thresholds=[0.6, 0.7, 0.7], # MTCNN thresholds
               post_process=True,
-              device='cpu'
+              device='cpu',
+              select_largest=False, # return result in descending order
         )
     return face_detector
 

--- a/deepface/detectors/FastMtcnnWrapper.py
+++ b/deepface/detectors/FastMtcnnWrapper.py
@@ -1,0 +1,52 @@
+import cv2
+from deepface.detectors import FaceDetector
+
+# Link -> https://github.com/timesler/facenet-pytorch
+# Examples https://www.kaggle.com/timesler/guide-to-mtcnn-in-facenet-pytorch
+
+def build_model():
+    # Optional dependency
+    from facenet_pytorch import MTCNN as fast_mtcnn
+
+
+    face_detector = fast_mtcnn(image_size=160,
+              thresholds=[0.6, 0.7, 0.7], # MTCNN thresholds
+              post_process=True,
+              device='cpu'
+        )
+    return face_detector
+
+def xyxy_to_xywh(xyxy):
+    """
+    Convert xyxy format to xywh format.
+    """
+    x, y = xyxy[0], xyxy[1]
+    w = xyxy[2] - x + 1
+    h = xyxy[3] - y + 1
+    return [x, y, w, h]
+
+def detect_face(face_detector, img, align=True):
+
+    resp = []
+
+    detected_face = None
+    img_region = [0, 0, img.shape[1], img.shape[0]]
+
+    img_rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)  # mtcnn expects RGB but OpenCV read BGR
+    detections = face_detector.detect(img_rgb, landmarks=True) # returns boundingbox, prob, landmark
+    if len(detections[0]) > 0:
+
+        for detection in zip(*detections):
+            x, y, w, h = xyxy_to_xywh(detection[0])
+            detected_face = img[int(y) : int(y + h), int(x) : int(x + w)]
+            img_region = [x, y, w, h]
+            confidence = detection[1]
+
+            if align:
+                left_eye = detection[2][0]
+                right_eye = detection[2][1]
+                detected_face = FaceDetector.alignment_procedure(detected_face, left_eye, right_eye)
+
+            resp.append((detected_face, img_region, confidence))
+
+    return resp

--- a/deepface/detectors/FastMtcnnWrapper.py
+++ b/deepface/detectors/FastMtcnnWrapper.py
@@ -8,9 +8,9 @@ def build_model():
     # Optional dependency
     try:
         from facenet_pytorch import MTCNN as fast_mtcnn
-    except ModuleNotFoundError:
-        print("This is an optional detector, ensure the library is installed. \
-              Please install using 'pip install facenet-pytorch' ")
+    except ModuleNotFoundError as e:
+        raise ImportError("This is an optional detector, ensure the library is installed. \
+              Please install using 'pip install facenet-pytorch' ") from e
 
 
     face_detector = fast_mtcnn(image_size=160,

--- a/requirements_additional.txt
+++ b/requirements_additional.txt
@@ -2,3 +2,4 @@ opencv-contrib-python>=4.3.0.36
 mediapipe>=0.8.7.3
 dlib>=19.20.0
 ultralytics>=8.0.122
+facenet-pytorch>=2.5.3


### PR DESCRIPTION
MTCNN gives a performs well for face detection tasks but can be slow too
I've included another implementation of mtcnn [`repo`](https://github.com/timesler/facenet-pytorch) which is quite faster than the standalone mtcnn. you can checkout their benchmark here [`here`](https://github.com/timesler/facenet-pytorch#performance-comparison-of-face-detection-packages).

The bounding box returned is similar too
Result on the same image:
fastmtcnn -> [{'age': 29,
  'region': {'x': 306, 'y': 458, 'w': 1035, 'h': 1381},
  'face_confidence': 0.9994694590568542},
 {'age': 34,
  'region': {'x': 286, 'y': 844, 'w': 46, 'h': 55},
  'face_confidence': 0.846997082233429}]

mtcnn -> [{'age': 29,
  'region': {'x': 305, 'y': 457, 'w': 1036, 'h': 1378},
  'face_confidence': 0.9993908405303955},
 {'age': 32,
  'region': {'x': 287, 'y': 844, 'w': 44, 'h': 52},
  'face_confidence': 0.7173819541931152}]


Another example:
fastmtcnn -> [{'age': 25,
  'region': {'x': 287, 'y': 136, 'w': 50, 'h': 68},
  'face_confidence': 1.0},
 {'age': 30,
  'region': {'x': 36, 'y': 147, 'w': 40, 'h': 54},
  'face_confidence': 0.9999947547912598},
 {'age': 33,
  'region': {'x': 383, 'y': 155, 'w': 33, 'h': 47},
  'face_confidence': 0.9999902248382568},
 {'age': 47,
  'region': {'x': 204, 'y': 143, 'w': 39, 'h': 54},
  'face_confidence': 0.9999575614929199},
 {'age': 29,
  'region': {'x': 121, 'y': 141, 'w': 51, 'h': 67},
  'face_confidence': 0.9998831748962402}]


mtcnn -> [{'age': 25,
  'region': {'x': 286, 'y': 134, 'w': 52, 'h': 71},
  'face_confidence': 1.0},
 {'age': 34,
  'region': {'x': 384, 'y': 156, 'w': 31, 'h': 44},
  'face_confidence': 0.9999959468841553},
 {'age': 33,
  'region': {'x': 36, 'y': 145, 'w': 40, 'h': 55},
  'face_confidence': 0.999796450138092},
 {'age': 45,
  'region': {'x': 205, 'y': 143, 'w': 39, 'h': 53},
  'face_confidence': 0.9995798468589783},
 {'age': 28,
  'region': {'x': 119, 'y': 139, 'w': 53, 'h': 70},
  'face_confidence': 0.9993777275085449}]

PS: the order might differ