### PR TITLE
Find method accepts representations and an option not to save representations

### DIFF
--- a/deepface/DeepFace.py
+++ b/deepface/DeepFace.py
@@ -406,6 +406,7 @@ def find(
     align=True,
     normalization="base",
     silent=False,
+    save_pickle=True
 ):
     """
     This function applies verification several times and find the identities in a database
@@ -532,8 +533,9 @@ def find(
 
         # -------------------------------
 
-        with open(f"{db_path}/{file_name}", "wb") as f:
-            pickle.dump(representations, f)
+        if save_pickle:
+            with open(f"{db_path}/{file_name}", "wb") as f:
+                pickle.dump(representations, f)
 
         if not silent:
             print(


### PR DESCRIPTION
There is an additional parameter not to save representations into the pickle file

When `extractions_db` parameter is set to `True`, `find()` will accept a list of returns from `representation()` as a `db_path`, because we needed to not store the entire images in our data