### PR TITLE
Fix missing normalization when skipping face detection

### DIFF
--- a/deepface/DeepFace.py
+++ b/deepface/DeepFace.py
@@ -684,6 +684,7 @@ def represent(
         if len(img.shape) == 3:
             img = cv2.resize(img, target_size)
             img = np.expand_dims(img, axis=0)
+            img /= 255
         # --------------------------------
         img_region = [0, 0, img.shape[1], img.shape[0]]
         img_objs = [(img, img_region, 0)]


### PR DESCRIPTION
When using the `DeepFace.represent` function where `detector_backend=skip`, the image is not properly normalized.
In particular, digging around the repo I found that this bug was introduced in 8f667ee: the line that divides the image's pixels by 255 is moved inside `functions.extract_faces`, which is skipped with the above mentioned keyword argument.

Therefore, the model's input image (in particular, I tried with ArcFace) has a distribution which is significantly different than the one used in training; as a consequence, the model has a significantly lower performance than advertised when tested on LFW (~64.5% with cosine distance).
On the contrary, when the image is manually normalized in the [0, 1] range, this accuracy is around ~91%.
I used DeepFace 0.0.79.

While waiting for this PR to be merged, I suggest anyone in the same situation to manually normalize your images converting them from BGR to RGB and manually normalizing them so that the pixels' range is [0, 1].
```python
rgb_image = cv2.cvtColor(bgr_image, cv2.COLOR_BGR2RGB).astype(np.float32)
rgb_image = rgb_image / 255
embedding = DeepFace.represent(img_path=rgb_image, model_name="ArcFace", detector_backend="skip")[0]["embedding"]
```