### PR TITLE
Catch exceptions when decoding invalid images

### DIFF
--- a/deepface/commons/functions.py
+++ b/deepface/commons/functions.py
@@ -117,11 +117,11 @@ def load_image(img):
             img = cv2.imdecode(chunk_arr, cv2.IMREAD_COLOR)
             return img
 
-        except cv2.error:
-            raise ValueError(f"Image '{img}' contains invalid data")
+        except cv2.error as exc:
+            raise ValueError(f"Image '{img}' contains invalid data") from exc
 
-        except Exception as e:
-            raise e
+        except Exception as exc:
+            raise exc
 
     # This causes troubles when reading files with non english names
     # return cv2.imread(img)

--- a/deepface/commons/functions.py
+++ b/deepface/commons/functions.py
@@ -107,10 +107,21 @@ def load_image(img):
 
     # For reading images with unicode names
     with open(img, "rb") as img_f:
-        chunk = img_f.read()
-        chunk_arr = np.frombuffer(chunk, dtype=np.uint8)
-        img = cv2.imdecode(chunk_arr, cv2.IMREAD_COLOR)
-    return img
+        try:
+            chunk = img_f.read()
+            chunk_arr = np.frombuffer(chunk, dtype=np.uint8)
+
+            if chunk_arr.size == 0:
+                raise ValueError(f"Image '{img}' is empty")
+
+            img = cv2.imdecode(chunk_arr, cv2.IMREAD_COLOR)
+            return img
+
+        except cv2.error:
+            raise ValueError(f"Image '{img}' contains invalid data")
+
+        except Exception as e:
+            raise e
 
     # This causes troubles when reading files with non english names
     # return cv2.imread(img)


### PR DESCRIPTION
Previously, attempting to decode images using `load_image` failed without explicitly 
stating where and why the operation failed.

For example, we use `np.frombuffer` to interpret the image data as an 1-dimensional array.
This operation _DOES NOT_ fail when the image file is empty.

In contrast, passing invalid or empty image data to `cv2.imdecode` _will_ raise an execption.
Which is what happens when we don't check for a buffer size > 0.

This PR resolves these issues mentioned above by checking if the computed `chunk_arr` is empty,
and if so raising a legible `ValueError`.

Finally, we assume that if the `cv2.imdecode` fails it's because the image file's data is corrupt 
in one way or another and raise `ValueError` for that too.

Fixes #890