### PR TITLE
incompatible bug for deepid in representation

### DIFF
--- a/deepface/modules/representation.py
+++ b/deepface/modules/representation.py
@@ -72,7 +72,7 @@ def represent(
     if detector_backend != "skip":
         img_objs = functions.extract_faces(
             img=img_path,
-            target_size=target_size,
+            target_size=(target_size[1], target_size[0]),
             detector_backend=detector_backend,
             grayscale=False,
             enforce_detection=enforce_detection,

--- a/tests/visual-test.py
+++ b/tests/visual-test.py
@@ -14,7 +14,7 @@ model_names = [
     "Facenet512",
     "OpenFace",
     "DeepFace",
-    # "DeepID",
+    "DeepID",
     "Dlib",
     "ArcFace",
     "SFace",


### PR DESCRIPTION
## Tickets

https://github.com/serengil/deepface/issues/963

### What has been done

With this PR, incompatible input size bug for deepid in representation is sorted. Interestingly, this is not problematic in verify.

## How to test

```shell
make lint && make test
```