### PR TITLE
Prevent no attribute error when using Mtcnn

### DIFF
--- a/deepface/detectors/FastMtCnn.py
+++ b/deepface/detectors/FastMtCnn.py
@@ -44,7 +44,7 @@ class FastMtCnnClient(Detector):
         detections = self.model.detect(
             img_rgb, landmarks=True
         )  # returns boundingbox, prob, landmark
-        if len(detections[0]) > 0:
+        if detections is not None and len(detections) > 0:
 
             for current_detection in zip(*detections):
                 x, y, w, h = xyxy_to_xywh(current_detection[0])

--- a/deepface/detectors/MtCnn.py
+++ b/deepface/detectors/MtCnn.py
@@ -46,7 +46,7 @@ class MtCnnClient(Detector):
         img_rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)  # mtcnn expects RGB but OpenCV read BGR
         detections = self.model.detect_faces(img_rgb)
 
-        if len(detections) > 0:
+        if detections is not None and len(detections) > 0:
 
             for current_detection in detections:
                 x, y, w, h = current_detection["box"]


### PR DESCRIPTION
### What has been done

When running this code with an image with no faces, a TypeError was encountered. Using short-circuit evaluation a condition was added to prevent this exception from occurring again.


```python 
Traceback (most recent call last):
  File "XXXXXXX.py", line 65, in find_face
    enforce_detection=enforce_detection)
  File "/home/YYYYYY/anaconda3/envs/facedetection/lib/python3.7/site-packages/deepface/DeepFace.py", line 451, in extract_faces
    grayscale=grayscale,
  File "/home/YYYYYY/anaconda3/envs/facedetection/lib/python3.7/site-packages/deepface/modules/detection.py", line 57, in extract_faces
    align=align,
  File "/home/YYYYYY/anaconda3/envs/facedetection/lib/python3.7/site-packages/deepface/commons/functions.py", line 178, in extract_faces
    face_objs = DetectorWrapper.detect_faces(detector_backend, img, align)
  File "/home/YYYYYY/anaconda3/envs/facedetection/lib/python3.7/site-packages/deepface/detectors/DetectorWrapper.py", line 78, in detect_faces
    return face_detector.detect_faces(img=img, align=align)
  File "/home/YYYYYY/anaconda3/envs/facedetection/lib/python3.7/site-packages/deepface/detectors/FastMtCnn.py", line 47, in detect_faces
    if len(detections[0]) > 0:
TypeError: object of type 'NoneType' has no len()
```

## How to test

```shell
make lint && make test
```