### PR TITLE
pretty return type for detect faces

### DIFF
--- a/deepface/detectors/DetectorWrapper.py
+++ b/deepface/detectors/DetectorWrapper.py
@@ -1,6 +1,6 @@
-from typing import Any
+from typing import Any, List
 import numpy as np
-from deepface.models.Detector import Detector
+from deepface.models.Detector import Detector, DetectedFace
 from deepface.detectors import (
     FastMtCnn,
     MediaPipe,
@@ -52,7 +52,7 @@ def build_model(detector_backend: str) -> Any:
     return face_detector_obj[detector_backend]
 
 
-def detect_faces(detector_backend: str, img: np.ndarray, align: bool = True) -> list:
+def detect_faces(detector_backend: str, img: np.ndarray, align: bool = True) -> List[DetectedFace]:
     """
     Detect face(s) from a given image
     Args:
@@ -60,19 +60,11 @@ def detect_faces(detector_backend: str, img: np.ndarray, align: bool = True) -> 
         img (np.ndarray): pre-loaded image
         alig (bool): enable or disable alignment after detection
     Returns:
-        results (List[Tuple[np.ndarray, List[float], float]]): A list of tuples
-            where each tuple contains:
-            - detected_face (np.ndarray): The detected face as a NumPy array.
-            - face_region (List[float]): The image region represented as
-                a list of floats e.g. [x, y, w, h]
+        results (List[DetectedFace]): A list of DetectedFace objects
+            where each object contains:
+            - img (np.ndarray): The detected face as a NumPy array.
+            - facial_area (FacialAreaRegion): The facial area region represented as x, y, w, h
             - confidence (float): The confidence score associated with the detected face.
-
-    Example:
-        results = [
-            (array(..., dtype=uint8), [110, 60, 150, 380], 0.99),
-            (array(..., dtype=uint8), [150, 50, 299, 375], 0.98),
-            (array(..., dtype=uint8), [120, 55, 300, 371], 0.96),
-        ]
     """
     face_detector: Detector = build_model(detector_backend)
     return face_detector.detect_faces(img=img, align=align)

--- a/deepface/detectors/FastMtCnn.py
+++ b/deepface/detectors/FastMtCnn.py
@@ -1,7 +1,7 @@
-from typing import Any, Union, List, Tuple
+from typing import Any, Union, List
 import cv2
 import numpy as np
-from deepface.models.Detector import Detector
+from deepface.models.Detector import Detector, DetectedFace, FacialAreaRegion
 from deepface.modules import detection
 
 # Link -> https://github.com/timesler/facenet-pytorch
@@ -12,33 +12,22 @@ class FastMtCnnClient(Detector):
     def __init__(self):
         self.model = self.build_model()
 
-    def detect_faces(
-        self, img: np.ndarray, align: bool = True
-    ) -> List[Tuple[np.ndarray, List[float], float]]:
+    def detect_faces(self, img: np.ndarray, align: bool = True) -> List[DetectedFace]:
         """
         Detect and align face with mtcnn
         Args:
             img (np.ndarray): pre-loaded image
             align (bool): default is true
         Returns:
-            results (List[Tuple[np.ndarray, List[float], float]]): A list of tuples
-                where each tuple contains:
-                - detected_face (np.ndarray): The detected face as a NumPy array.
-                - face_region (List[float]): The image region represented as
-                    a list of floats e.g. [x, y, w, h]
-                - confidence (float): The confidence score associated with the detected face.
-
-        Example:
-            results = [
-                (array(..., dtype=uint8), [110, 60, 150, 380], 0.99),
-                (array(..., dtype=uint8), [150, 50, 299, 375], 0.98),
-                (array(..., dtype=uint8), [120, 55, 300, 371], 0.96),
-            ]
+            results (List[DetectedFace]): A list of DetectedFace objects
+                where each object contains:
+            - img (np.ndarray): The detected face as a NumPy array.
+            - facial_area (FacialAreaRegion): The facial area region represented as x, y, w, h
+            - confidence (float): The confidence score associated with the detected face.
         """
         resp = []
 
         detected_face = None
-        img_region = [0, 0, img.shape[1], img.shape[0]]
 
         img_rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)  # mtcnn expects RGB but OpenCV read BGR
         detections = self.model.detect(
@@ -49,7 +38,7 @@ class FastMtCnnClient(Detector):
             for current_detection in zip(*detections):
                 x, y, w, h = xyxy_to_xywh(current_detection[0])
                 detected_face = img[int(y) : int(y + h), int(x) : int(x + w)]
-                img_region = [x, y, w, h]
+                img_region = FacialAreaRegion(x=x, y=y, w=w, h=h)
                 confidence = current_detection[1]
 
                 if align:
@@ -59,7 +48,11 @@ class FastMtCnnClient(Detector):
                         img=detected_face, left_eye=left_eye, right_eye=right_eye
                     )
 
-                resp.append((detected_face, img_region, confidence))
+                detected_face_obj = DetectedFace(
+                    img=detected_face, facial_area=img_region, confidence=confidence
+                )
+
+                resp.append(detected_face_obj)
 
         return resp
 

--- a/deepface/detectors/MtCnn.py
+++ b/deepface/detectors/MtCnn.py
@@ -1,8 +1,8 @@
-from typing import List, Tuple
+from typing import List
 import cv2
 import numpy as np
 from mtcnn import MTCNN
-from deepface.models.Detector import Detector
+from deepface.models.Detector import Detector, DetectedFace, FacialAreaRegion
 from deepface.modules import detection
 
 # pylint: disable=too-few-public-methods
@@ -14,34 +14,23 @@ class MtCnnClient(Detector):
     def __init__(self):
         self.model = MTCNN()
 
-    def detect_faces(
-        self, img: np.ndarray, align: bool = True
-    ) -> List[Tuple[np.ndarray, List[float], float]]:
+    def detect_faces(self, img: np.ndarray, align: bool = True) -> List[DetectedFace]:
         """
         Detect and align face with mtcnn
         Args:
             img (np.ndarray): pre-loaded image
             align (bool): default is true
         Returns:
-            results (List[Tuple[np.ndarray, List[float], float]]): A list of tuples
-                where each tuple contains:
-                - detected_face (np.ndarray): The detected face as a NumPy array.
-                - face_region (List[float]): The image region represented as
-                    a list of floats e.g. [x, y, w, h]
-                - confidence (float): The confidence score associated with the detected face.
-
-        Example:
-            results = [
-                (array(..., dtype=uint8), [110, 60, 150, 380], 0.99),
-                (array(..., dtype=uint8), [150, 50, 299, 375], 0.98),
-                (array(..., dtype=uint8), [120, 55, 300, 371], 0.96),
-            ]
+            results (List[DetectedFace]): A list of DetectedFace objects
+                where each object contains:
+            - img (np.ndarray): The detected face as a NumPy array.
+            - facial_area (FacialAreaRegion): The facial area region represented as x, y, w, h
+            - confidence (float): The confidence score associated with the detected face.
         """
 
         resp = []
 
         detected_face = None
-        img_region = [0, 0, img.shape[1], img.shape[0]]
 
         img_rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)  # mtcnn expects RGB but OpenCV read BGR
         detections = self.model.detect_faces(img_rgb)
@@ -51,7 +40,7 @@ class MtCnnClient(Detector):
             for current_detection in detections:
                 x, y, w, h = current_detection["box"]
                 detected_face = img[int(y) : int(y + h), int(x) : int(x + w)]
-                img_region = [x, y, w, h]
+                img_region = FacialAreaRegion(x=x, y=y, w=w, h=h)
                 confidence = current_detection["confidence"]
 
                 if align:
@@ -62,6 +51,10 @@ class MtCnnClient(Detector):
                         img=detected_face, left_eye=left_eye, right_eye=right_eye
                     )
 
-                resp.append((detected_face, img_region, confidence))
+                detected_face_obj = DetectedFace(
+                    img=detected_face, facial_area=img_region, confidence=confidence
+                )
+
+                resp.append(detected_face_obj)
 
         return resp

--- a/deepface/detectors/OpenCv.py
+++ b/deepface/detectors/OpenCv.py
@@ -1,8 +1,8 @@
 import os
-from typing import Any, List, Tuple
+from typing import Any, List
 import cv2
 import numpy as np
-from deepface.models.Detector import Detector
+from deepface.models.Detector import Detector, DetectedFace, FacialAreaRegion
 from deepface.modules import detection
 
 
@@ -25,9 +25,7 @@ class OpenCvClient(Detector):
         detector["eye_detector"] = self.__build_cascade("haarcascade_eye")
         return detector
 
-    def detect_faces(
-        self, img: np.ndarray, align: bool = True
-    ) -> List[Tuple[np.ndarray, List[float], float]]:
+    def detect_faces(self, img: np.ndarray, align: bool = True) -> List[DetectedFace]:
         """
         Detect and align face with opencv
         Args:
@@ -35,24 +33,15 @@ class OpenCvClient(Detector):
             img (np.ndarray): pre-loaded image
             align (bool): default is true
         Returns:
-            results (List[Tuple[np.ndarray, List[float], float]]): A list of tuples
-                where each tuple contains:
-                - detected_face (np.ndarray): The detected face as a NumPy array.
-                - face_region (List[float]): The image region represented as
-                    a list of floats e.g. [x, y, w, h]
-                - confidence (float): The confidence score associated with the detected face.
-
-        Example:
-            results = [
-                (array(..., dtype=uint8), [110, 60, 150, 380], 0.99),
-                (array(..., dtype=uint8), [150, 50, 299, 375], 0.98),
-                (array(..., dtype=uint8), [120, 55, 300, 371], 0.96),
-            ]
+            results (List[Tuple[DetectedFace]): A list of DetectedFace objects
+                where each object contains:
+            - img (np.ndarray): The detected face as a NumPy array.
+            - facial_area (FacialAreaRegion): The facial area region represented as x, y, w, h
+            - confidence (float): The confidence score associated with the detected face.
         """
         resp = []
 
         detected_face = None
-        img_region = [0, 0, img.shape[1], img.shape[0]]
 
         faces = []
         try:
@@ -73,9 +62,13 @@ class OpenCvClient(Detector):
                     left_eye, right_eye = self.find_eyes(img=detected_face)
                     detected_face = detection.align_face(detected_face, left_eye, right_eye)
 
-                img_region = [x, y, w, h]
+                detected_face_obj = DetectedFace(
+                    img=detected_face,
+                    facial_area=FacialAreaRegion(x, y, w, h),
+                    confidence=confidence,
+                )
 
-                resp.append((detected_face, img_region, confidence))
+                resp.append(detected_face_obj)
 
         return resp
 

--- a/deepface/detectors/YuNet.py
+++ b/deepface/detectors/YuNet.py
@@ -1,10 +1,10 @@
 import os
-from typing import Any, List, Tuple
+from typing import Any, List
 import cv2
 import numpy as np
 import gdown
 from deepface.commons import functions
-from deepface.models.Detector import Detector
+from deepface.models.Detector import Detector, DetectedFace, FacialAreaRegion
 from deepface.modules import detection
 from deepface.commons.logger import Logger
 
@@ -49,35 +49,24 @@ class YuNetClient(Detector):
             ) from err
         return face_detector
 
-    def detect_faces(
-        self, img: np.ndarray, align: bool = True
-    ) -> List[Tuple[np.ndarray, List[float], float]]:
+    def detect_faces(self, img: np.ndarray, align: bool = True) -> List[DetectedFace]:
         """
         Detect and align face with yunet
         Args:
             img (np.ndarray): pre-loaded image
             align (bool): default is true
         Returns:
-            results (List[Tuple[np.ndarray, List[float], float]]): A list of tuples
-                where each tuple contains:
-                - detected_face (np.ndarray): The detected face as a NumPy array.
-                - face_region (List[float]): The image region represented as
-                    a list of floats e.g. [x, y, w, h]
-                - confidence (float): The confidence score associated with the detected face.
-
-        Example:
-            results = [
-                (array(..., dtype=uint8), [110, 60, 150, 380], 0.99),
-                (array(..., dtype=uint8), [150, 50, 299, 375], 0.98),
-                (array(..., dtype=uint8), [120, 55, 300, 371], 0.96),
-            ]
+            results (List[DetectedFace]): A list of DetectedFace objects
+                where each object contains:
+            - img (np.ndarray): The detected face as a NumPy array.
+            - facial_area (FacialAreaRegion): The facial area region represented as x, y, w, h
+            - confidence (float): The confidence score associated with the detected face.
         """
         # FaceDetector.detect_faces does not support score_threshold parameter.
         # We can set it via environment variable.
         score_threshold = float(os.environ.get("yunet_score_threshold", "0.9"))
         resp = []
         detected_face = None
-        img_region = [0, 0, img.shape[1], img.shape[0]]
         faces = []
         height, width = img.shape[0], img.shape[1]
         # resize image if it is too large (Yunet fails to detect faces on large input sometimes)
@@ -127,8 +116,12 @@ class YuNetClient(Detector):
             confidence = face[-1]
             confidence = f"{confidence:.2f}"
             detected_face = img[int(y) : int(y + h), int(x) : int(x + w)]
-            img_region = [x, y, w, h]
+            img_region = FacialAreaRegion(x=x, y=y, w=w, h=h)
             if align:
                 detected_face = detection.align_face(detected_face, (x_re, y_re), (x_le, y_le))
-            resp.append((detected_face, img_region, confidence))
+
+            detected_face_obj = DetectedFace(
+                img=detected_face, facial_area=img_region, confidence=confidence
+            )
+            resp.append(detected_face_obj)
         return resp

--- a/deepface/models/Detector.py
+++ b/deepface/models/Detector.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 from abc import ABC, abstractmethod
 import numpy as np
 
@@ -8,27 +8,42 @@ import numpy as np
 # pylint: disable=unnecessary-pass, too-few-public-methods
 class Detector(ABC):
     @abstractmethod
-    def detect_faces(
-        self, img: np.ndarray, align: bool = True
-    ) -> List[Tuple[np.ndarray, List[float], float]]:
+    def detect_faces(self, img: np.ndarray, align: bool = True) -> List["DetectedFace"]:
         """
         Detect faces from a given image
         Args:
             img (np.ndarray): pre-loaded image as a NumPy array
             align (bool): enable or disable alignment after face detection
         Returns:
-            results (List[Tuple[np.ndarray, List[float], float]]): A list of tuples
-                where each tuple contains:
-                - detected_face (np.ndarray): The detected face as a NumPy array.
+            results (List[DetectedFace]): A list of DetectedFace object
+                where each object contains:
+                - face (np.ndarray): The detected face as a NumPy array.
                 - face_region (List[float]): The image region represented as
                     a list of floats e.g. [x, y, w, h]
                 - confidence (float): The confidence score associated with the detected face.
-
-        Example:
-            results = [
-                (array(..., dtype=uint8), [110, 60, 150, 380], 0.99),
-                (array(..., dtype=uint8), [150, 50, 299, 375], 0.98),
-                (array(..., dtype=uint8), [120, 55, 300, 371], 0.96),
-            ]
         """
         pass
+
+
+class FacialAreaRegion:
+    x: int
+    y: int
+    w: int
+    h: int
+
+    def __init__(self, x: int, y: int, w: int, h: int):
+        self.x = x
+        self.y = y
+        self.w = w
+        self.h = h
+
+
+class DetectedFace:
+    img: np.ndarray
+    facial_area: FacialAreaRegion
+    confidence: float
+
+    def __init__(self, img: np.ndarray, facial_area: FacialAreaRegion, confidence: float):
+        self.img = img
+        self.facial_area = facial_area
+        self.confidence = confidence

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r", encoding="utf-8") as f:
 
 setuptools.setup(
     name="deepface",
-    version="0.0.83",
+    version="0.0.84",
     author="Sefik Ilkin Serengil",
     author_email="serengil@gmail.com",
     description="A Lightweight Face Recognition and Facial Attribute Analysis Framework (Age, Gender, Emotion, Race) for Python",

--- a/tests/visual-test.py
+++ b/tests/visual-test.py
@@ -20,8 +20,7 @@ model_names = [
     "SFace",
 ]
 
-detector_backends = ["opencv", "ssd", "dlib", "mtcnn", "retinaface", "yunet"]
-
+detector_backends = ["opencv", "ssd", "dlib", "mtcnn", "retinaface", "yunet", "yolov8"]
 
 # verification
 for model_name in model_names:
@@ -44,7 +43,6 @@ dfs = DeepFace.find(
 )
 for df in dfs:
     logger.info(df)
-
 
 # extract faces
 for detector_backend in detector_backends:


### PR DESCRIPTION
## Tickets

- https://github.com/serengil/deepface/issues/977

### What has been done

With this PR, return type of Detector.detect_faces and its all inherited classes changed from `List[Tuple[np.ndarray, List[float], float]]` to `List[DetectedFace]` and DetectedFace class has detected image itself as numpy array, facial area region with x, y, w, h coordinates and face confidence score.

## How to test

```shell
make lint && make test
```