### PR TITLE
Correct info about returned types for the represent method

### DIFF
--- a/deepface/DeepFace.py
+++ b/deepface/DeepFace.py
@@ -345,7 +345,7 @@ def represent(
         results (List[Dict[str, Any]]): A list of dictionaries, each containing the
             following fields:
 
-        - embedding (np.array): Multidimensional vector representing facial features.
+        - embedding (List[float]): Multidimensional vector representing facial features.
             The number of dimensions varies based on the reference model
             (e.g., FaceNet returns 128 dimensions, VGG-Face returns 4096 dimensions).
 

--- a/deepface/modules/representation.py
+++ b/deepface/modules/representation.py
@@ -47,7 +47,7 @@ def represent(
         results (List[Dict[str, Any]]): A list of dictionaries, each containing the
             following fields:
 
-        - embedding (np.array): Multidimensional vector representing facial features.
+        - embedding (List[float]): Multidimensional vector representing facial features.
             The number of dimensions varies based on the reference model
             (e.g., FaceNet returns 128 dimensions, VGG-Face returns 4096 dimensions).
         - facial_area (dict): Detected facial area by face detection in dictionary format.


### PR DESCRIPTION
### What has been done

Small fix to the documentation of the represent method: the embedding is returned as a list of floats, not a multidimensional array.

### How to test

The code hasn't been changed, only the documentation