### PR TITLE
Simplify and strengthen rotate_facial_area

### DIFF
--- a/deepface/detectors/DetectorWrapper.py
+++ b/deepface/detectors/DetectorWrapper.py
@@ -124,11 +124,13 @@ def detect_faces(
                 img=img, left_eye=left_eye, right_eye=right_eye
             )
             rotated_x1, rotated_y1, rotated_x2, rotated_y2 = rotate_facial_area(
-                facial_area=(x, y, x + w, y + h), 
-                angle=angle, 
+                facial_area=(x, y, x + w, y + h),
+                angle=angle,
                 size=(img.shape[0], img.shape[1])
             )
-            detected_face = aligned_img[int(rotated_y1) : int(rotated_y2), int(rotated_x1) : int(rotated_x2)]
+            detected_face = aligned_img[
+                int(rotated_y1) : int(rotated_y2),
+                int(rotated_x1) : int(rotated_x2)]
 
         result = DetectedFace(
             img=detected_face,
@@ -142,7 +144,7 @@ def detect_faces(
 
 
 def rotate_facial_area(
-    facial_area: Tuple[int, int, int, int], 
+    facial_area: Tuple[int, int, int, int],
     angle: float,               # in degrees. The sign determines the direction of rotation
     size: Tuple[int, int]       # (width, height)
 ) -> Tuple[int, int, int, int]:

--- a/deepface/detectors/DetectorWrapper.py
+++ b/deepface/detectors/DetectorWrapper.py
@@ -104,18 +104,6 @@ def detect_faces(
         confidence = facial_area.confidence
 
         if expand_percentage > 0:
-            # Uncomment this if you want to :
-            # Expand the facial area to be extracted and recompute the height and width
-            # keeping the same aspect ratio and ensuring that the expanded area stays
-            # within img.shape limits
-
-            # current_area = w * h
-            # expanded_area = current_area + int((current_area * expand_percentage) / 100)
-            # scale_factor = math.sqrt(expanded_area / current_area)
-            # expanded_w = int(w * scale_factor)
-            # expanded_h = int(h * scale_factor)
-
-            # Or uncomment this if you want to :
             # Expand the facial region height and width by the provided percentage
             # ensuring that the expanded region stays within img.shape limits
             expanded_w = w + int(w * expand_percentage / 100)

--- a/deepface/detectors/DetectorWrapper.py
+++ b/deepface/detectors/DetectorWrapper.py
@@ -129,12 +129,6 @@ def detect_faces(
         # extract detected face unaligned
         detected_face = img[int(y) : int(y + h), int(x) : int(x + w)]
 
-        # aligning detected face causes a lot of black pixels
-        # if align is True:
-        #     detected_face, _ = detection.align_face(
-        #         img=detected_face, left_eye=left_eye, right_eye=right_eye
-        #     )
-
         # align original image, then find projection of detected face area after alignment
         if align is True:  # and left_eye is not None and right_eye is not None:
             aligned_img, angle = detection.align_face(

--- a/deepface/detectors/DetectorWrapper.py
+++ b/deepface/detectors/DetectorWrapper.py
@@ -123,10 +123,12 @@ def detect_faces(
             aligned_img, angle = detection.align_face(
                 img=img, left_eye=left_eye, right_eye=right_eye
             )
-            x1_new, y1_new, x2_new, y2_new = rotate_facial_area(
-                facial_area=(x2, y2, x2 + w2, y2 + h2), angle=angle, direction=1, size=img.shape
+            rotated_x1, rotated_y1, rotated_x2, rotated_y2 = rotate_facial_area(
+                facial_area=(x, y, x + w, y + h), 
+                angle=angle, 
+                size=(img.shape[0], img.shape[1])
             )
-            detected_face = aligned_img[int(y1_new) : int(y2_new), int(x1_new) : int(x2_new)]
+            detected_face = aligned_img[int(rotated_y1) : int(rotated_y2), int(rotated_x1) : int(rotated_x2)]
 
         result = DetectedFace(
             img=detected_face,
@@ -140,7 +142,9 @@ def detect_faces(
 
 
 def rotate_facial_area(
-    facial_area: Tuple[int, int, int, int], angle: float, direction: int, size: Tuple[int, int]
+    facial_area: Tuple[int, int, int, int], 
+    angle: float,               # in degrees. The sign determines the direction of rotation
+    size: Tuple[int, int]       # (width, height)
 ) -> Tuple[int, int, int, int]:
     """
     Rotate the facial area around its center.
@@ -149,14 +153,22 @@ def rotate_facial_area(
     Args:
         facial_area (tuple of int): Representing the (x1, y1, x2, y2) of the facial area.
             x2 is equal to x1 + w1, and y2 is equal to y1 + h1
-        angle (float): Angle of rotation in degrees.
-        direction (int): Direction of rotation (-1 for clockwise, 1 for counterclockwise).
+        angle (float): Angle of rotation in degrees. Its sign determines the direction of rotation.
+                       Note that angles > 360 degrees are normalized to the range [0, 360).
         size (tuple of int): Tuple representing the size of the image (width, height).
 
     Returns:
         rotated_coordinates (tuple of int): Representing the new coordinates
             (x1, y1, x2, y2) or (x1, y1, x1+w1, y1+h1) of the rotated facial area.
     """
+
+    # Normalize the witdh of the angle so we don't have to
+    # worry about rotations greater than 360 degrees
+    angle = angle % 360
+    if angle == 0:
+        return facial_area # No rotation needed
+    direction = 1 if angle > 0 else -1
+
     # Angle in radians
     angle = angle * np.pi / 180
 

--- a/deepface/detectors/DetectorWrapper.py
+++ b/deepface/detectors/DetectorWrapper.py
@@ -144,8 +144,8 @@ def detect_faces(
 
 def rotate_facial_area(
     facial_area: Tuple[int, int, int, int],
-    angle: float,               # in degrees. The sign determines the direction of rotation
-    size: Tuple[int, int]       # (width, height)
+    angle: float,
+    size: Tuple[int, int]
 ) -> Tuple[int, int, int, int]:
     """
     Rotate the facial area around its center.

--- a/deepface/detectors/DetectorWrapper.py
+++ b/deepface/detectors/DetectorWrapper.py
@@ -164,11 +164,13 @@ def rotate_facial_area(
     """
 
     # Normalize the witdh of the angle so we don't have to
-    # worry about rotations greater than 360 degrees
-    angle = angle % 360
+    # worry about rotations greater than 360 degrees.
+    # We workaround the quirky behavior of the modulo operator
+    # for negative angle values.
+    direction = (1, -1)[angle < 0]
+    angle = abs(angle) % 360
     if angle == 0:
-        return facial_area # No rotation needed
-    direction = 1 if angle > 0 else -1
+        return facial_area
 
     # Angle in radians
     angle = angle * np.pi / 180

--- a/deepface/detectors/DetectorWrapper.py
+++ b/deepface/detectors/DetectorWrapper.py
@@ -103,14 +103,31 @@ def detect_faces(
         right_eye = facial_area.right_eye
         confidence = facial_area.confidence
 
-        # expand the facial area to be extracted and stay within img.shape limits
-        x2 = max(0, x - int((w * expand_percentage) / 100))  # expand left
-        y2 = max(0, y - int((h * expand_percentage) / 100))  # expand top
-        w2 = min(img.shape[1], w + int((w * 2 * expand_percentage) / 100))  # expand right
-        h2 = min(img.shape[0], h + int((h * 2 * expand_percentage) / 100))  # expand bottom
+        if expand_percentage > 0:
+            # Uncomment this if you want to :
+            # Expand the facial area to be extracted and recompute the height and width
+            # keeping the same aspect ratio and ensuring that the expanded area stays
+            # within img.shape limits
+
+            # current_area = w * h
+            # expanded_area = current_area + int((current_area * expand_percentage) / 100)
+            # scale_factor = math.sqrt(expanded_area / current_area)
+            # expanded_w = int(w * scale_factor)
+            # expanded_h = int(h * scale_factor)
+
+            # Or uncomment this if you want to :
+            # Expand the facial region height and width by the provided percentage
+            # ensuring that the expanded region stays within img.shape limits
+            expanded_w = int(w * expand_percentage / 100)
+            expanded_h = int(h * expand_percentage / 100)
+
+            x = max(0, x - int((expanded_w - w) / 2))
+            y = max(0, y - int((expanded_h - h) / 2))
+            w = min(img.shape[1] - x, expanded_w)
+            h = min(img.shape[0] - y, expanded_h)
 
         # extract detected face unaligned
-        detected_face = img[int(y2) : int(y2 + h2), int(x2) : int(x2 + w2)]
+        detected_face = img[int(y) : int(y + h), int(x) : int(x + w)]
 
         # aligning detected face causes a lot of black pixels
         # if align is True:

--- a/deepface/detectors/DetectorWrapper.py
+++ b/deepface/detectors/DetectorWrapper.py
@@ -167,7 +167,7 @@ def rotate_facial_area(
     # worry about rotations greater than 360 degrees.
     # We workaround the quirky behavior of the modulo operator
     # for negative angle values.
-    direction = (1, -1)[angle < 0]
+    direction = 1 if angle >= 0 else -1
     angle = abs(angle) % 360
     if angle == 0:
         return facial_area

--- a/deepface/detectors/DetectorWrapper.py
+++ b/deepface/detectors/DetectorWrapper.py
@@ -118,8 +118,8 @@ def detect_faces(
             # Or uncomment this if you want to :
             # Expand the facial region height and width by the provided percentage
             # ensuring that the expanded region stays within img.shape limits
-            expanded_w = int(w * expand_percentage / 100)
-            expanded_h = int(h * expand_percentage / 100)
+            expanded_w = w + int(w * expand_percentage / 100)
+            expanded_h = h + int(h * expand_percentage / 100)
 
             x = max(0, x - int((expanded_w - w) / 2))
             y = max(0, y - int((expanded_h - h) / 2))


### PR DESCRIPTION
This strengthen `rotate_facial_area` by :
 - constraining rotation angle in range [0, 360)
 - early bailout in case angle == 0
 - deriving direction of rotation from sign of  `angle` : positive values for clockwise, negative for anti-clockwise

In previous implementation direction could be any number causing unwanted results.

Also fixes #1045 