### PR TITLE
returning image name in value error

### DIFF
--- a/deepface/modules/detection.py
+++ b/deepface/modules/detection.py
@@ -27,6 +27,7 @@ elif tf_major_version == 2:
 
 def extract_faces(
     img_path: Union[str, np.ndarray],
+    img_name: str = "",
     target_size: Optional[Tuple[int, int]] = (224, 224),
     detector_backend: str = "opencv",
     enforce_detection: bool = True,
@@ -76,7 +77,7 @@ def extract_faces(
     resp_objs = []
 
     # img might be path, base64 or numpy array. Convert it to numpy whatever it is.
-    img, img_name = preprocessing.load_image(img_path)
+    img, img_name = preprocessing.load_image(img_path, img_name)
 
     if img is None:
         raise ValueError(f"Exception while loading {img_name}")

--- a/deepface/modules/preprocessing.py
+++ b/deepface/modules/preprocessing.py
@@ -9,7 +9,10 @@ import cv2
 import requests
 
 
-def load_image(img: Union[str, np.ndarray]) -> Tuple[np.ndarray, str]:
+def load_image(
+    img: Union[str, np.ndarray],
+    img_name: str = ""
+) -> Tuple[np.ndarray, str]:
     """
     Load image from path, url, base64 or numpy array.
     Args:
@@ -21,17 +24,17 @@ def load_image(img: Union[str, np.ndarray]) -> Tuple[np.ndarray, str]:
 
     # The image is already a numpy array
     if isinstance(img, np.ndarray):
-        return img, "numpy array"
+        return img, f"{img_name} numpy array"
 
     if isinstance(img, Path):
         img = str(img)
 
     if not isinstance(img, str):
-        raise ValueError(f"img must be numpy array or str but it is {type(img)}")
+        raise ValueError(f"{img_name} must be numpy array or str but it is {type(img)}")
 
     # The image is a base64 string
     if img.startswith("data:image/"):
-        return load_base64(img), "base64 encoded string"
+        return load_base64(img), f"{img_name} base64 encoded string"
 
     # The image is a url
     if img.startswith("http"):

--- a/deepface/modules/representation.py
+++ b/deepface/modules/representation.py
@@ -64,9 +64,11 @@ def represent(
     # ---------------------------------
     # we have run pre-process in verification. so, this can be skipped if it is coming from verify.
     target_size = model.input_shape
+    img_name = "img"
     if detector_backend != "skip":
         img_objs = detection.extract_faces(
             img_path=img_path,
+            img_name= img_name,
             target_size=(target_size[1], target_size[0]),
             detector_backend=detector_backend,
             grayscale=False,
@@ -76,7 +78,7 @@ def represent(
         )
     else:  # skip
         # Try load. If load error, will raise exception internal
-        img, _ = preprocessing.load_image(img_path)
+        img, _ = preprocessing.load_image(img_path, img_name)
         # --------------------------------
         if len(img.shape) == 4:
             img = img[0]  # e.g. (1, 224, 224, 3) to (224, 224, 3)

--- a/deepface/modules/verification.py
+++ b/deepface/modules/verification.py
@@ -88,6 +88,7 @@ def verify(
     # img pairs might have many faces
     img1_objs = detection.extract_faces(
         img_path=img1_path,
+        img_name = "img1_path",
         target_size=target_size,
         detector_backend=detector_backend,
         grayscale=False,
@@ -98,6 +99,7 @@ def verify(
 
     img2_objs = detection.extract_faces(
         img_path=img2_path,
+        img_name = "img2_path",
         target_size=target_size,
         detector_backend=detector_backend,
         grayscale=False,


### PR DESCRIPTION
## Tickets

https://github.com/serengil/deepface/issues/1056

### What has been done

With this PR, 
returns argument name img1_path / img2_path, when verify function is called with base64 / numpy array, if face is not found in img1_path or img2_path it return the name _img1_path_ or _img2_path_ with ValueError exception msg.

## How to test

```shell
make lint && make test
```