### PR TITLE
added functionality for dynamic database-picke-file

### DIFF
--- a/deepface/DeepFace.py
+++ b/deepface/DeepFace.py
@@ -235,6 +235,8 @@ def find(
     threshold: Optional[float] = None,
     normalization: str = "base",
     silent: bool = False,
+    refresh_database: bool = True,
+    updated_images: list[str] = []
 ) -> List[pd.DataFrame]:
     """
     Identify individuals in a database
@@ -272,6 +274,16 @@ def find(
 
         silent (boolean): Suppress or allow some log messages for a quieter analysis process
             (default is False).
+            
+        refresh_database (boolean): Checks if the files contained in the database directory/folder
+        were altered and updates the pkl file if the updated_images is empty, else it will check 
+        specifically for the images in the path (should be the same as the database) and will try 
+        to upload/reload them into the picke file
+
+        updated_images (list[str]): list of the images in the same path as the db (example: 
+        ['home/user/database/img_92.jpg'] would be a valid list if and only if the database also 
+        was given by 'home/user/database/') that sould be updated
+
 
     Returns:
         results (List[pd.DataFrame]): A list of pandas dataframes. Each dataframe corresponds
@@ -303,6 +315,8 @@ def find(
         threshold=threshold,
         normalization=normalization,
         silent=silent,
+        refresh_database = refresh_database,
+        updated_images= updated_images,
     )
 
 

--- a/deepface/commons/sets_utils.py
+++ b/deepface/commons/sets_utils.py
@@ -1,0 +1,6 @@
+def intersection(set1:set, set2:set) -> set:
+    return {element for element in set1 if element in set2}
+
+def is_subset(set1:set, set2:set) -> bool:
+    "Returns true if set1 is a subset of set2"
+    return intersection(set1, set2) == set1


### PR DESCRIPTION
Now the find function can get also a refresh and updated_files argument so that you can load only once the whole database to a pickle file and, as you are using it, you update the files individualy as needed

### What has been done

With this PR, the find function will be able to work without the need for the whole set of images to be in the database directory/folder which, in cases of a big enough database and/or runing the function in the cloud could lower the prices for persistent memory usage besides making it more secure by not storing the images directly in the computer (but, instead, only its picked representations)

Since no functionality were added to the feature of face-recognition itself, the tests can be made individually by simply adding an image to a data base, turning off the refresh feature and deleting the image and noticing that the function is still working; turning on and adding another file to the path and it to the list of new files and noticing that the only change is that the file will be added to the picke file and the one that was not in the list of updated_images won't be touched.

The documentation was added only within the function file itself, but in case this PR is accepted, I will be also adding it to the readme file as needed. :)