### PR TITLE
hash with properties instead of file itself

### DIFF
--- a/deepface/commons/package_utils.py
+++ b/deepface/commons/package_utils.py
@@ -1,7 +1,6 @@
 # built-in dependencies
 import os
 import hashlib
-import platform
 
 # 3rd party dependencies
 import tensorflow as tf

--- a/deepface/commons/package_utils.py
+++ b/deepface/commons/package_utils.py
@@ -1,5 +1,7 @@
 # built-in dependencies
+import os
 import hashlib
+import platform
 
 # 3rd party dependencies
 import tensorflow as tf
@@ -21,12 +23,22 @@ def get_tf_major_version() -> int:
 
 def find_hash_of_file(file_path: str) -> str:
     """
-    Find hash of image file
+    Find the hash of given image file with its properties
+        finding the hash of image content is costly operation
     Args:
         file_path (str): exact image path
     Returns:
         hash (str): digest with sha1 algorithm
     """
-    with open(file_path, "rb") as f:
-        digest = hashlib.sha1(f.read()).hexdigest()
-    return digest
+    file_stats = os.stat(file_path)
+
+    # some properties
+    file_size = file_stats.st_size
+    creation_time = file_stats.st_ctime
+    modification_time = file_stats.st_mtime
+
+    properties = f"{file_size}-{creation_time}-{modification_time}"
+
+    hasher = hashlib.sha1()
+    hasher.update(properties.encode("utf-8"))
+    return hasher.hexdigest()

--- a/deepface/modules/demography.py
+++ b/deepface/modules/demography.py
@@ -96,7 +96,7 @@ def analyze(
                - 'white': Confidence score for White ethnicity.
     """
 
-    # validate actions
+    # if actions is passed as tuple with single item, interestingly it becomes str here
     if isinstance(actions, str):
         actions = (actions,)
 


### PR DESCRIPTION
## Tickets

https://github.com/serengil/deepface/issues/1061

### What has been done

With this PR, we calculated hash of a file with its properties such as file size, created time, modified time instead of image content.

## How to test

```shell
make lint && make test
```