### PR TITLE
layer for external models are no longer being used

### DIFF
--- a/deepface/basemodels/Dlib.py
+++ b/deepface/basemodels/Dlib.py
@@ -64,14 +64,8 @@ class DlibResNet:
                 "Please install using 'pip install dlib' "
             ) from e
 
-        self.layers = [DlibMetaData()]
-
-        # ---------------------
-
         home = folder_utils.get_deepface_home()
         weight_file = home + "/.deepface/weights/dlib_face_recognition_resnet_model_v1.dat"
-
-        # ---------------------
 
         # download pre-trained model if it does not exist
         if os.path.isfile(weight_file) != True:
@@ -88,15 +82,6 @@ class DlibResNet:
             with open(newfilepath, "wb") as f:
                 f.write(data)
 
-        # ---------------------
-
         self.model = dlib.face_recognition_model_v1(weight_file)
 
-        # ---------------------
-
         # return None  # classes must return None
-
-
-class DlibMetaData:
-    def __init__(self):
-        self.input_shape = [[1, 150, 150, 3]]

--- a/deepface/basemodels/SFace.py
+++ b/deepface/basemodels/SFace.py
@@ -80,10 +80,3 @@ class SFaceWrapper:
                 + "This is an optional dependency."
                 + "You can install it as pip install opencv-contrib-python."
             ) from err
-
-        self.layers = [_Layer()]
-
-
-class _Layer:
-    input_shape = (None, 112, 112, 3)
-    output_shape = (None, 1, 128)


### PR DESCRIPTION
## Tickets

https://github.com/serengil/deepface/issues/1090

### What has been done

In the early versions of deepface, we were grabbing the target size of an image from the model's layers object's input_shape argument. This is available for keras based model but not available for external models such as Dlib or SFace. That is why, we added a layer object in the wrapper and referenced a class. However, we are now having input shape and output shape arguments in the base model's clients already. So, layers is not being used.

With this PR, we retired the layer object of external models.

## How to test

```shell
make lint && make test
```