### PR TITLE
Feat task 2803 moving find embedding methods to super if not require additional logic

### DIFF
--- a/deepface/basemodels/ArcFace.py
+++ b/deepface/basemodels/ArcFace.py
@@ -1,7 +1,5 @@
-from typing import List
 import os
 import gdown
-import numpy as np
 from deepface.commons import package_utils, folder_utils
 from deepface.commons.logger import Logger
 from deepface.models.FacialRecognition import FacialRecognition

--- a/deepface/basemodels/ArcFace.py
+++ b/deepface/basemodels/ArcFace.py
@@ -56,18 +56,6 @@ class ArcFaceClient(FacialRecognition):
         self.input_shape = (112, 112)
         self.output_shape = 512
 
-    def find_embeddings(self, img: np.ndarray) -> List[float]:
-        """
-        find embeddings with ArcFace model
-        Args:
-            img (np.ndarray): pre-loaded image in BGR
-        Returns
-            embeddings (list): multi-dimensional vector
-        """
-        # model.predict causes memory issue when it is called in a for loop
-        # embedding = model.predict(img, verbose=0)[0].tolist()
-        return self.model(img, training=False).numpy()[0].tolist()
-
 
 def load_model(
     url="https://github.com/serengil/deepface_models/releases/download/v1.0/arcface_weights.h5",

--- a/deepface/basemodels/DeepID.py
+++ b/deepface/basemodels/DeepID.py
@@ -1,7 +1,5 @@
-from typing import List
 import os
 import gdown
-import numpy as np
 from deepface.commons import package_utils, folder_utils
 from deepface.commons.logger import Logger
 from deepface.models.FacialRecognition import FacialRecognition

--- a/deepface/basemodels/DeepID.py
+++ b/deepface/basemodels/DeepID.py
@@ -52,18 +52,6 @@ class DeepIdClient(FacialRecognition):
         self.input_shape = (47, 55)
         self.output_shape = 160
 
-    def find_embeddings(self, img: np.ndarray) -> List[float]:
-        """
-        find embeddings with DeepId model
-        Args:
-            img (np.ndarray): pre-loaded image in BGR
-        Returns
-            embeddings (list): multi-dimensional vector
-        """
-        # model.predict causes memory issue when it is called in a for loop
-        # embedding = model.predict(img, verbose=0)[0].tolist()
-        return self.model(img, training=False).numpy()[0].tolist()
-
 
 def load_model(
     url="https://github.com/serengil/deepface_models/releases/download/v1.0/deepid_keras_weights.h5",

--- a/deepface/basemodels/Dlib.py
+++ b/deepface/basemodels/Dlib.py
@@ -23,9 +23,10 @@ class DlibClient(FacialRecognition):
         self.input_shape = (150, 150)
         self.output_shape = 128
 
-    def find_embeddings(self, img: np.ndarray) -> List[float]:
+    def forward(self, img: np.ndarray) -> List[float]:
         """
-        find embeddings with Dlib model - different than regular models
+        Find embeddings with Dlib model
+            Overwritten because it is different than regular models
         Args:
             img (np.ndarray): pre-loaded image in BGR
         Returns

--- a/deepface/basemodels/Dlib.py
+++ b/deepface/basemodels/Dlib.py
@@ -25,8 +25,9 @@ class DlibClient(FacialRecognition):
 
     def forward(self, img: np.ndarray) -> List[float]:
         """
-        Find embeddings with Dlib model
-            Overwritten because it is different than regular models
+        Find embeddings with Dlib model.
+            This model necessitates the override of the forward method
+            because it is not a keras model.
         Args:
             img (np.ndarray): pre-loaded image in BGR
         Returns

--- a/deepface/basemodels/Facenet.py
+++ b/deepface/basemodels/Facenet.py
@@ -1,7 +1,5 @@
-from typing import List
 import os
 import gdown
-import numpy as np
 from deepface.commons import package_utils, folder_utils
 from deepface.commons.logger import Logger
 from deepface.models.FacialRecognition import FacialRecognition

--- a/deepface/basemodels/Facenet.py
+++ b/deepface/basemodels/Facenet.py
@@ -56,18 +56,6 @@ class FaceNet128dClient(FacialRecognition):
         self.input_shape = (160, 160)
         self.output_shape = 128
 
-    def find_embeddings(self, img: np.ndarray) -> List[float]:
-        """
-        find embeddings with FaceNet-128d model
-        Args:
-            img (np.ndarray): pre-loaded image in BGR
-        Returns
-            embeddings (list): multi-dimensional vector
-        """
-        # model.predict causes memory issue when it is called in a for loop
-        # embedding = model.predict(img, verbose=0)[0].tolist()
-        return self.model(img, training=False).numpy()[0].tolist()
-
 
 class FaceNet512dClient(FacialRecognition):
     """
@@ -79,18 +67,6 @@ class FaceNet512dClient(FacialRecognition):
         self.model_name = "FaceNet-512d"
         self.input_shape = (160, 160)
         self.output_shape = 512
-
-    def find_embeddings(self, img: np.ndarray) -> List[float]:
-        """
-        find embeddings with FaceNet-512d model
-        Args:
-            img (np.ndarray): pre-loaded image in BGR
-        Returns
-            embeddings (list): multi-dimensional vector
-        """
-        # model.predict causes memory issue when it is called in a for loop
-        # embedding = model.predict(img, verbose=0)[0].tolist()
-        return self.model(img, training=False).numpy()[0].tolist()
 
 
 def scaling(x, scale):

--- a/deepface/basemodels/FbDeepFace.py
+++ b/deepface/basemodels/FbDeepFace.py
@@ -56,18 +56,6 @@ class DeepFaceClient(FacialRecognition):
         self.input_shape = (152, 152)
         self.output_shape = 4096
 
-    def find_embeddings(self, img: np.ndarray) -> List[float]:
-        """
-        find embeddings with OpenFace model
-        Args:
-            img (np.ndarray): pre-loaded image in BGR
-        Returns
-            embeddings (list): multi-dimensional vector
-        """
-        # model.predict causes memory issue when it is called in a for loop
-        # embedding = model.predict(img, verbose=0)[0].tolist()
-        return self.model(img, training=False).numpy()[0].tolist()
-
 
 def load_model(
     url="https://github.com/swghosh/DeepFace/releases/download/weights-vggface2-2d-aligned/VGGFace2_DeepFace_weights_val-0.9034.h5.zip",

--- a/deepface/basemodels/FbDeepFace.py
+++ b/deepface/basemodels/FbDeepFace.py
@@ -1,8 +1,6 @@
-from typing import List
 import os
 import zipfile
 import gdown
-import numpy as np
 from deepface.commons import package_utils, folder_utils
 from deepface.commons.logger import Logger
 from deepface.models.FacialRecognition import FacialRecognition

--- a/deepface/basemodels/GhostFaceNet.py
+++ b/deepface/basemodels/GhostFaceNet.py
@@ -1,10 +1,8 @@
 # built-in dependencies
 import os
-from typing import List
 
 # 3rd party dependencies
 import gdown
-import numpy as np
 import tensorflow as tf
 
 # project dependencies

--- a/deepface/basemodels/GhostFaceNet.py
+++ b/deepface/basemodels/GhostFaceNet.py
@@ -72,11 +72,6 @@ class GhostFaceNetClient(FacialRecognition):
         self.output_shape = 512
         self.model = load_model()
 
-    def find_embeddings(self, img: np.ndarray) -> List[float]:
-        # model.predict causes memory issue when it is called in a for loop
-        # embedding = model.predict(img, verbose=0)[0].tolist()
-        return self.model(img, training=False).numpy()[0].tolist()
-
 
 def load_model():
     model = GhostFaceNetV1()

--- a/deepface/basemodels/OpenFace.py
+++ b/deepface/basemodels/OpenFace.py
@@ -1,8 +1,6 @@
-from typing import List
 import os
 import gdown
 import tensorflow as tf
-import numpy as np
 from deepface.commons import package_utils, folder_utils
 from deepface.commons.logger import Logger
 from deepface.models.FacialRecognition import FacialRecognition

--- a/deepface/basemodels/OpenFace.py
+++ b/deepface/basemodels/OpenFace.py
@@ -39,18 +39,6 @@ class OpenFaceClient(FacialRecognition):
         self.input_shape = (96, 96)
         self.output_shape = 128
 
-    def find_embeddings(self, img: np.ndarray) -> List[float]:
-        """
-        find embeddings with OpenFace model
-        Args:
-            img (np.ndarray): pre-loaded image in BGR
-        Returns
-            embeddings (list): multi-dimensional vector
-        """
-        # model.predict causes memory issue when it is called in a for loop
-        # embedding = model.predict(img, verbose=0)[0].tolist()
-        return self.model(img, training=False).numpy()[0].tolist()
-
 
 def load_model(
     url="https://github.com/serengil/deepface_models/releases/download/v1.0/openface_weights.h5",

--- a/deepface/basemodels/SFace.py
+++ b/deepface/basemodels/SFace.py
@@ -25,9 +25,10 @@ class SFaceClient(FacialRecognition):
         self.input_shape = (112, 112)
         self.output_shape = 128
 
-    def find_embeddings(self, img: np.ndarray) -> List[float]:
+    def forward(self, img: np.ndarray) -> List[float]:
         """
-        find embeddings with SFace model - different than regular models
+        Find embeddings with SFace model
+            Overwritten because it is different than regular models
         Args:
             img (np.ndarray): pre-loaded image in BGR
         Returns

--- a/deepface/basemodels/SFace.py
+++ b/deepface/basemodels/SFace.py
@@ -28,7 +28,8 @@ class SFaceClient(FacialRecognition):
     def forward(self, img: np.ndarray) -> List[float]:
         """
         Find embeddings with SFace model
-            Overwritten because it is different than regular models
+            This model necessitates the override of the forward method
+            because it is not a keras model.
         Args:
             img (np.ndarray): pre-loaded image in BGR
         Returns

--- a/deepface/basemodels/VGGFace.py
+++ b/deepface/basemodels/VGGFace.py
@@ -47,9 +47,12 @@ class VggFaceClient(FacialRecognition):
         self.input_shape = (224, 224)
         self.output_shape = 4096
 
-    def find_embeddings(self, img: np.ndarray) -> List[float]:
+    def forward(self, img: np.ndarray) -> List[float]:
         """
-        find embeddings with VGG-Face model
+        Generates embeddings using the VGG-Face model.
+            This method incorporates an additional normalization layer,
+            necessitating the override of the forward method.
+
         Args:
             img (np.ndarray): pre-loaded image in BGR
         Returns
@@ -57,6 +60,7 @@ class VggFaceClient(FacialRecognition):
         """
         # model.predict causes memory issue when it is called in a for loop
         # embedding = model.predict(img, verbose=0)[0].tolist()
+
         # having normalization layer in descriptor troubles for some gpu users (e.g. issue 957, 966)
         # instead we are now calculating it with traditional way not with keras backend
         embedding = self.model(img, training=False).numpy()[0].tolist()

--- a/deepface/models/FacialRecognition.py
+++ b/deepface/models/FacialRecognition.py
@@ -18,7 +18,12 @@ class FacialRecognition(ABC):
     input_shape: Tuple[int, int]
     output_shape: int
 
-
-    @abstractmethod
-    def find_embeddings(self, img: np.ndarray) -> List[float]:
-        pass
+    def forward(self, img: np.ndarray) -> List[float]:
+        if not isinstance(self.model, Model):
+            raise ValueError(
+                "You must overwrite forward method if it is not a keras model,"
+                f"but {self.model_name} not overwritten!"
+            )
+        # model.predict causes memory issue when it is called in a for loop
+        # embedding = model.predict(img, verbose=0)[0].tolist()
+        return self.model(img, training=False).numpy()[0].tolist()

--- a/deepface/models/FacialRecognition.py
+++ b/deepface/models/FacialRecognition.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import ABC
 from typing import Any, Union, List, Tuple
 import numpy as np
 from deepface.commons import package_utils

--- a/deepface/modules/representation.py
+++ b/deepface/modules/representation.py
@@ -104,7 +104,7 @@ def represent(
         # custom normalization
         img = preprocessing.normalize_input(img=img, normalization=normalization)
 
-        embedding = model.find_embeddings(img)
+        embedding = model.forward(img)
 
         resp_obj = {}
         resp_obj["embedding"] = embedding

--- a/tests/face-recognition-how.py
+++ b/tests/face-recognition-how.py
@@ -23,11 +23,11 @@ logger.info(f"target_size: {target_size}")
 
 img1 = DeepFace.extract_faces(img_path="dataset/img1.jpg", target_size=target_size)[0]["face"]
 img1 = np.expand_dims(img1, axis=0)  # to (1, 224, 224, 3)
-img1_representation = model.find_embeddings(img1)
+img1_representation = model.forward(img1)
 
 img2 = DeepFace.extract_faces(img_path="dataset/img3.jpg", target_size=target_size)[0]["face"]
 img2 = np.expand_dims(img2, axis=0)
-img2_representation = model.find_embeddings(img2)
+img2_representation = model.forward(img2)
 
 img1_representation = np.array(img1_representation)
 img2_representation = np.array(img2_representation)


### PR DESCRIPTION
## Tickets

https://github.com/serengil/deepface/issues/1150

### What has been done

With this PR, formerly find_embeddings and currently forward methods of base models removed it they do not require additional work. In that way, these will use its super's forward method. In that way, we will not copy same code for different base models.

## How to test

```shell
make lint && make test
```