### PR TITLE
README.md Assert Statement Code Typo Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ This function returns an array as embedding. The size of the embedding array wou
 ```python
 embedding = embedding_objs[0]["embedding"]
 assert isinstance(embedding, list)
-assert model_name = "VGG-Face" and len(embedding) == 4096
+assert model_name == "VGG-Face" and len(embedding) == 4096
 ```
 
 Here, embedding is also [plotted](https://sefiks.com/2020/05/01/a-gentle-introduction-to-face-recognition-in-deep-learning/) with 4096 slots horizontally. Each slot is corresponding to a dimension value in the embedding vector and dimension value is explained in the colorbar on the right. Similar to 2D barcodes, vertical dimension stores no information in the illustration.


### PR DESCRIPTION
### What has been done

With this PR, I fixed a minor error in the `README.md` file where a Python `assert` statement will always be listed as True if the length of the embedding NumPy array is equivalent to 4096, when it is also supposed to check that the model used was the `VGG-Face` model. As a fix, instead of Python's assignment operator `=`, which will always return True, I replaced it with Python's equivalence `==` operator to ensure `README.md` correctness in the code test for accessing this particular embedding.