### PR TITLE
accept optional parameter - 'threshold' in verify method

### DIFF
--- a/deepface/DeepFace.py
+++ b/deepface/DeepFace.py
@@ -72,6 +72,7 @@ def verify(
     expand_percentage: int = 0,
     normalization: str = "base",
     silent: bool = False,
+    threshold: Optional[float] = None,
 ) -> Dict[str, Any]:
     """
     Verify if an image pair represents the same person or different persons.
@@ -106,6 +107,11 @@ def verify(
 
         silent (boolean): Suppress or allow some log messages for a quieter analysis process
             (default is False).
+
+        threshold (float): Specify a threshold to determine whether a pair represents the same
+            person or different individuals. This threshold is used for comparing distances.
+            If left unset, default pre-tuned threshold values will be applied based on the specified
+            model name and distance metric (default is None).
 
     Returns:
         result (dict): A dictionary containing verification results with following keys.
@@ -143,6 +149,7 @@ def verify(
         expand_percentage=expand_percentage,
         normalization=normalization,
         silent=silent,
+        threshold=threshold,
     )
 
 

--- a/deepface/modules/verification.py
+++ b/deepface/modules/verification.py
@@ -1,6 +1,6 @@
 # built-in dependencies
 import time
-from typing import Any, Dict, Union, List, Tuple
+from typing import Any, Dict, Optional, Union, List, Tuple
 
 # 3rd party dependencies
 import numpy as np
@@ -24,6 +24,7 @@ def verify(
     expand_percentage: int = 0,
     normalization: str = "base",
     silent: bool = False,
+    threshold: Optional[float] = None,
 ) -> Dict[str, Any]:
     """
     Verify if an image pair represents the same person or different persons.
@@ -63,6 +64,11 @@ def verify(
 
         silent (boolean): Suppress or allow some log messages for a quieter analysis process
             (default is False).
+        
+        threshold (float): Specify a threshold to determine whether a pair represents the same
+            person or different individuals. This threshold is used for comparing distances.
+            If left unset, default pre-tuned threshold values will be applied based on the specified
+            model name and distance metric (default is None).
 
     Returns:
         result (dict): A dictionary containing verification results.
@@ -186,7 +192,7 @@ def verify(
             )
 
     # find the face pair with minimum distance
-    threshold = find_threshold(model_name, distance_metric)
+    threshold = threshold or find_threshold(model_name, distance_metric)
     distance = float(min(distances))  # best distance
     facial_areas = facial_areas[np.argmin(distances)]
 


### PR DESCRIPTION
### What has been done

Unlike [find](https://github.com/serengil/deepface/blob/master/deepface/DeepFace.py#L244) method, [verify](https://github.com/serengil/deepface/blob/master/deepface/DeepFace.py#L64) doesn't allow passing a custom threshold value. Custom threshold will be useful in case people want the verification to be more strict. This PR adds support for an optional _threshold_ parameter that can be passed to `verify` method