### PR TITLE
fix docstring max_threshold_to_verify in verify method

### DIFF
--- a/deepface/DeepFace.py
+++ b/deepface/DeepFace.py
@@ -116,7 +116,7 @@ def verify(
         - 'distance' (float): The distance measure between the face vectors.
             A lower distance indicates higher similarity.
 
-        - 'max_threshold_to_verify' (float): The maximum threshold used for verification.
+        - 'threshold' (float): The maximum threshold used for verification.
             If the distance is below this threshold, the images are considered a match.
 
         - 'model' (str): The chosen face recognition model.

--- a/deepface/modules/verification.py
+++ b/deepface/modules/verification.py
@@ -73,7 +73,7 @@ def verify(
         - 'distance' (float): The distance measure between the face vectors.
             A lower distance indicates higher similarity.
 
-        - 'max_threshold_to_verify' (float): The maximum threshold used for verification.
+        - 'threshold' (float): The maximum threshold used for verification.
             If the distance is below this threshold, the images are considered a match.
 
         - 'model' (str): The chosen face recognition model.


### PR DESCRIPTION
### What has been done

The docstring of the verify method had a incorrect key `max_threshold_to_verify`(probably due to old code). This PR updates it to `threshold` which is what returned by the verify method.

Note:
The [image in README.md](https://raw.githubusercontent.com/serengil/deepface/master/icon/stock-1.jpg) still has the `max_threshold_to_verify` in it which needs to be updated. Let me know if you want to update it since I don't have the project file.