### PR TITLE
ISSUE #1233: Feature refresh_database argument added to method find

### DIFF
--- a/deepface/DeepFace.py
+++ b/deepface/DeepFace.py
@@ -260,6 +260,7 @@ def find(
     threshold: Optional[float] = None,
     normalization: str = "base",
     silent: bool = False,
+    refresh_database: bool = True,
 ) -> List[pd.DataFrame]:
     """
     Identify individuals in a database
@@ -299,6 +300,10 @@ def find(
         silent (boolean): Suppress or allow some log messages for a quieter analysis process
             (default is False).
 
+        refresh_data_base (boolean): Sincronizes the images representation (pkl) file with the 
+        directory/db files, if set to false, it will ignore any file changes inside the db_path
+        (default is True).
+
     Returns:
         results (List[pd.DataFrame]): A list of pandas dataframes. Each dataframe corresponds
             to the identity information for an individual detected in the source image.
@@ -329,6 +334,7 @@ def find(
         threshold=threshold,
         normalization=normalization,
         silent=silent,
+        refresh_data_base=refresh_database,
     )
 
 

--- a/deepface/DeepFace.py
+++ b/deepface/DeepFace.py
@@ -300,7 +300,7 @@ def find(
         silent (boolean): Suppress or allow some log messages for a quieter analysis process
             (default is False).
 
-        refresh_data_base (boolean): Sincronizes the images representation (pkl) file with the 
+        refresh_database (boolean): Synchronizes the images representation (pkl) file with the 
         directory/db files, if set to false, it will ignore any file changes inside the db_path
         (default is True).
 
@@ -334,7 +334,7 @@ def find(
         threshold=threshold,
         normalization=normalization,
         silent=silent,
-        refresh_data_base=refresh_database,
+        refresh_database=refresh_database,
     )
 
 

--- a/deepface/modules/recognition.py
+++ b/deepface/modules/recognition.py
@@ -29,7 +29,7 @@ def find(
     threshold: Optional[float] = None,
     normalization: str = "base",
     silent: bool = False,
-    refresh_data_base: bool = True,
+    refresh_database: bool = True,
 ) -> List[pd.DataFrame]:
     """
     Identify individuals in a database
@@ -68,7 +68,7 @@ def find(
 
         silent (boolean): Suppress or allow some log messages for a quieter analysis process.
 
-        refresh_data_base (boolean): Sincronizes the images representation (pkl) file with the 
+        refresh_database (boolean): Synchronizes the images representation (pkl) file with the 
         directory/db files, if set to false, it will ignore any file changes inside the db_path 
         directory (default is True).
 
@@ -156,12 +156,12 @@ def find(
     old_images = []
     replaced_images = []
 
-    if not refresh_data_base:
-        logger.info(f"There could be changes in {db_path} not tracked. Set refresh_data_base to true to assure that any changes will be tracked.")
+    if not refresh_database:
+        logger.info(f"There could be changes in {db_path} not tracked. Set refresh_database to true to assure that any changes will be tracked.")
 
 
     # Enforce data consistency amongst on disk images and pickle file
-    if refresh_data_base:
+    if refresh_database:
         if len(storage_images) == 0:
             raise ValueError(f"No item found in {db_path}")
 
@@ -170,7 +170,6 @@ def find(
         old_images = list(set(pickled_images) - set(storage_images))  # images removed from storage
 
         # detect replaced images
-        replaced_images = []
         for current_representation in representations:
             identity = current_representation["identity"]
             if identity in old_images:


### PR DESCRIPTION
## Tickets

https://github.com/serengil/deepface/issues/1233

### What has been done

With this PR, the method refresh_database (boolean) allows the user to choose between sync the pkl file with the database directory and keep it up to date with the files inside that directory or ignore any file changes and do the recognition only with the representations in the pkl file.
Also a logger.info saying that the user is possibly out of sync for better user experience;

## How to test

```shell
make lint && make test
```