### PR TITLE
Face alignment with rotation using resample

### DIFF
--- a/deepface/modules/detection.py
+++ b/deepface/modules/detection.py
@@ -177,5 +177,5 @@ def align_face(
         return img, 0
 
     angle = float(np.degrees(np.arctan2(left_eye[1] - right_eye[1], left_eye[0] - right_eye[0])))
-    img = np.array(Image.fromarray(img).rotate(angle))
+    img = np.array(Image.fromarray(img).rotate(angle, resample=Image.BICUBIC))
     return img, angle


### PR DESCRIPTION
If you set the face `alignment` parameter to `True`, you can see pixel artefacts when you rotate the face horizontally over the eyes when working with faces of smaller dimensions.

## Original Image

![musk-2](https://github.com/serengil/deepface/assets/2056896/e1ae292e-2c6a-4dff-923e-9a23d2f86d7a)

## Face alignment

![musk-result](https://github.com/serengil/deepface/assets/2056896/42947727-efb8-474c-98ef-540187dd5dcc)

You can easily notice the changed pixels after rotation.

## Rotate with `resample=Image.BICUBIC`

![musk-result-2](https://github.com/serengil/deepface/assets/2056896/71e269b3-6f1c-43ae-b999-1661b0e3e906)

This PR adds a `resample=Image.BICUBIC` parameter to the align_face function, which smooths the changed pixels after face alignment.

## What does it improve?

Firstly, there are now better facial images after calling `DeepFace.extract_faces()`

I initially had a theory that these **deformed pixels** are passed to the models to turn the face into vectors and thus affect the result for the worse. 

I compared the two photos through all algorithms to see if smoothing via `resample=Image.BICUBIC` helps or not.

| Image A | Image B |
|---|---|
|![musk-2](https://github.com/serengil/deepface/assets/2056896/3cd93b81-368a-4768-b0ea-b4f759cbb080)| ![musk-4](https://github.com/serengil/deepface/assets/2056896/17141ab7-9b68-4a7d-8d6e-97ed97b78260)|

### Code

```python
result = DeepFace.verify(
    img1_path="musk-2.png",
    img2_path="musk-4.png",
    detector_backend=back,
    model_name=model,
    align=True
)
```

Each check was first run without `Image.BICUBIC`, then a second check with the same models was run with `Image.BICUBIC`

The **entire report** is at the link: https://docs.google.com/spreadsheets/d/1BPWT7bqz60QHu5y2Zx7Dhx0Kty4o_FDrVtf0vZYaTOw/edit?usp=sharing

* on the green background are the results where smoothing has improved the test result
* on the red background are the results where smoothing slightly worsened the result

## Conclusions

This change affects faces from **low resolution images**. In large images - deformed pixels are not noticeable after rotation.

From the Excel report in the [link above](https://docs.google.com/spreadsheets/d/1BPWT7bqz60QHu5y2Zx7Dhx0Kty4o_FDrVtf0vZYaTOw/edit?usp=sharing), it is noticeable that on the green background the percentage of difference is much higher than 12-19%. That is 12-19% improvement in the validation result between the two faces.

At the same time there is also a red background, but there the percentage of deterioration of the result is much lower.