### PR TITLE
Fix extract faces grayscale

### DIFF
--- a/deepface/DeepFace.py
+++ b/deepface/DeepFace.py
@@ -503,8 +503,8 @@ def extract_faces(
 
         expand_percentage (int): expand detected facial area with a percentage (default is 0).
 
-        grayscale (boolean): Flag to convert the image to grayscale before
-            processing (default is False).
+        grayscale (boolean): Flag to convert the output face image to grayscale
+            (default is False).
 
         anti_spoofing (boolean): Flag to enable anti spoofing (default is False).
 

--- a/deepface/modules/detection.py
+++ b/deepface/modules/detection.py
@@ -45,8 +45,8 @@ def extract_faces(
 
         expand_percentage (int): expand detected facial area with a percentage
 
-        grayscale (boolean): Flag to convert the image to grayscale before
-            processing (default is False).
+        grayscale (boolean): Flag to convert the output face image to grayscale
+            (default is False).
 
         anti_spoofing (boolean): Flag to enable anti spoofing (default is False).
 

--- a/deepface/modules/detection.py
+++ b/deepface/modules/detection.py
@@ -125,7 +125,7 @@ def extract_faces(
         h = int(current_region.h)
 
         resp_obj = {
-            "face": current_img[:, :, ::-1],
+            "face": current_img if grayscale else current_img[:, :, ::-1],
             "facial_area": {
                 "x": x,
                 "y": y,


### PR DESCRIPTION
### What has been done

When activating to return the face in grayscale, an error occurs because it tries to convert from BGR to RGB, but the image is in grayscale.

![image](https://github.com/user-attachments/assets/a2e03476-a2b5-47af-b7f4-7aeba13a9785)


## How to test

Fixed to allow returning the face image in grayscale, to test you can use the following command:
```
faces = DeepFace.extract_faces(
    img_path = 'image.jpg',
    grayscale = True
)
```