### PR TITLE
few improvements

### DIFF
--- a/deepface/DeepFace.py
+++ b/deepface/DeepFace.py
@@ -270,6 +270,7 @@ def find(
     silent: bool = False,
     refresh_database: bool = True,
     anti_spoofing: bool = False,
+    recursive: bool = True,
 ) -> List[pd.DataFrame]:
     """
     Identify individuals in a database
@@ -280,6 +281,8 @@ def find(
 
         db_path (string): Path to the folder containing image files. All detected faces
             in the database will be considered in the decision-making process.
+
+        recursive (bool): Walk db_path recursively (default True)
 
         model_name (str): Model for face recognition. Options: VGG-Face, Facenet, Facenet512,
             OpenFace, DeepFace, DeepID, Dlib, ArcFace, SFace and GhostFaceNet (default is VGG-Face).
@@ -347,6 +350,7 @@ def find(
         silent=silent,
         refresh_database=refresh_database,
         anti_spoofing=anti_spoofing,
+        recursive=recursive,
     )
 
 

--- a/deepface/commons/image_utils.py
+++ b/deepface/commons/image_utils.py
@@ -13,28 +13,45 @@ import cv2
 from PIL import Image
 
 
-def list_images(path: str) -> List[str]:
+def is_image(file_path: str) -> bool:
+    """
+    Check if a file is an image
+    Args:
+        file_path (str): path to the file
+    Returns:
+        bool: True if the file is an image, False otherwise
+    """
+    _, ext = os.path.splitext(file_path)
+    ext_lower = ext.lower()
+
+    if ext_lower not in {".jpg", ".jpeg", ".png", ".webp"}:
+        return False
+
+    with Image.open(file_path) as img:  # lazy
+        return img.format.lower() in ["jpeg", "png"]
+
+
+def list_images(path: str, recursive: bool = True) -> List[str]:
     """
     List images in a given path
     Args:
         path (str): path's location
+        recursive (bool): default True
     Returns:
         images (list): list of exact image paths
     """
     images = []
-    for r, _, f in os.walk(path):
-        for file in f:
-            exact_path = os.path.join(r, file)
-
-            _, ext = os.path.splitext(exact_path)
-            ext_lower = ext.lower()
-
-            if ext_lower not in {".jpg", ".jpeg", ".png"}:
-                continue
-
-            with Image.open(exact_path) as img:  # lazy
-                if img.format.lower() in ["jpeg", "png"]:
+    if recursive:
+        for r, _, f in os.walk(path):
+            for file in f:
+                exact_path = os.path.join(r, file)
+                if is_image(exact_path):
                     images.append(exact_path)
+    else:
+        for file in os.listdir(path):
+            exact_path = os.path.join(path, file)
+            if is_image(exact_path):
+                images.append(exact_path)
     return images
 
 
@@ -94,10 +111,6 @@ def load_image(img: Union[str, np.ndarray]) -> Tuple[np.ndarray, str]:
         raise ValueError(f"Confirm that {img} exists")
 
     # image must be a file on the system then
-
-    # image name must have english characters
-    if img.isascii() is False:
-        raise ValueError(f"Input image must not have non-english characters - {img}")
 
     img_obj_bgr = cv2.imread(img)
     # img_obj_rgb = cv2.cvtColor(img_obj_bgr, cv2.COLOR_BGR2RGB)


### PR DESCRIPTION
### What has been done

I use this library and found few things that I need. Maybe you can merge.

1. Disable recursive `db_path` walk in find function
2. Remove `Input image must not have non-english characters` error. In my system all works fine, idk why you've added this. If it's really important, you can make it a warning or optional. Definitely should be disablable 
3. Interupt searching by pressing ctrl+C if `DEEPFACE_KEYBOARD_INTERRUPT` env variable is set. Useful for big searches - just press ctrl+c and thanks to caching, you can get results now, and continue the search later
