### PR TITLE
Represent optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ benchmarks/results
 benchmarks/outputs
 benchmarks/dataset
 benchmarks/lfwe
+venv

--- a/deepface/modules/detection.py
+++ b/deepface/modules/detection.py
@@ -329,7 +329,7 @@ def align_img_wrt_eyes(
 
     (h, w) = img.shape[:2]
     center = (w // 2, h // 2)
-    M = cv2.getRotationMatrix2D(center, -angle, 1.0)
+    M = cv2.getRotationMatrix2D(center, angle, 1.0)
     img = cv2.warpAffine(img, M, (w, h), flags=cv2.INTER_CUBIC, borderMode=cv2.BORDER_CONSTANT, borderValue=(0,0,0))
 
     return img, angle

--- a/deepface/modules/representation.py
+++ b/deepface/modules/representation.py
@@ -81,6 +81,7 @@ def represent(
             align=align,
             expand_percentage=expand_percentage,
             anti_spoofing=anti_spoofing,
+            max_faces=max_faces,
         )
     else:  # skip
         # Try load. If load error, will raise exception internal


### PR DESCRIPTION
https://github.com/serengil/deepface/issues/1318

I've discovered that when using the `represent` api, the align phase is the slowest part, and was causing a bottleneck for my usecase. 

The slow part was actually in aligning all the faces in the image. I have created a PR that speeds this up by using cv2 to rotate the face image slice rather than converting it into a PIL image. This speeds up the process dramatically.

I have also ensured that the `max_faces` parameter is passed down into the `detect_faces` function so that it only aligns the number of faces it needs to, rather than aligning them all and discarding the ones we dont need.

Together these two changes provide roughly an order of magnitude improvement in terms of speed when calling `represent`.

I just have one question though, is the way I'm aligning the faces with cv2 optimal / correct, or is there something different with the implementation compared to PIL? I don't have much experience with python image manipulation, but it seems to work well for my use case.