### PR TITLE
Tiny fix: changed index to label in ssd detector

### DIFF
--- a/deepface/models/face_detection/Ssd.py
+++ b/deepface/models/face_detection/Ssd.py
@@ -107,7 +107,7 @@ class SsdClient(Detector):
 
         resp = []
         for face in faces:
-            confidence = float(face[2])
+            confidence = float(face[ssd_labels.confidence])
             x, y, w, h = map(int, face[margins])
             detected_face = img[y : y + h, x : x + w]
 


### PR DESCRIPTION
## What has been done

With this PR, the index in `face` has beed replaced with corresponding label.

## How to test
```shell
make lint && make test
```