### PR TITLE
Improvement: check image exists first

### DIFF
--- a/deepface/modules/recognition.py
+++ b/deepface/modules/recognition.py
@@ -100,6 +100,10 @@ def find(
     if not os.path.isdir(db_path):
         raise ValueError(f"Passed path {db_path} does not exist!")
 
+    img, _ = image_utils.load_image(img_path)
+    if img is None:
+        raise ValueError(f"Passed image path {img_path} does not exist!")
+
     file_parts = [
         "ds",
         "model",


### PR DESCRIPTION
## What has been done

With this PR, image existence checking has been added in `recognition.py`. The reason for this change is to solve the situtation that occurs when attempting to find similar faces using the `find` function. Previously, the function first collected embeddings from the database before searching for faces in the target image. If the path to the target image was incorrect or the image did not exist, the exception would only be raised **after** the database scan, which could be time-consuming.

## How to test
```shell
make lint && make test
```