### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ keras>=2.2.0
 Flask>=1.1.2
 flask_cors>=4.0.1
 mtcnn>=0.1.0
-retina-face>=0.0.1
+retina-face>=0.0.14
 fire>=0.4.0
 gunicorn>=20.1.0


### PR DESCRIPTION
## Tickets

deepface requires unnecessary depth resolution of retina_face upon installation of deepface dependencies

![image](https://github.com/user-attachments/assets/91e02dba-db5c-4c7c-a2d6-82ce2cafba7c)

### What has been done

tightened the versioning of retina_face so that resolvers only need to go 3 deep

## How to test

Build dev release, test, publish as dev release, encourage small group install locally for feedback before publishing as stable