### PR TITLE
Update CenterFace threshold

### DIFF
--- a/deepface/models/face_detection/CenterFace.py
+++ b/deepface/models/face_detection/CenterFace.py
@@ -46,7 +46,7 @@ class CenterFaceClient(Detector):
         """
         resp = []
 
-        threshold = float(os.getenv("CENTERFACE_THRESHOLD", "0.80"))
+        threshold = float(os.getenv("CENTERFACE_THRESHOLD", "0.35"))
 
         # BUG: model causes problematic results from 2nd call if it is not flushed
         # detections, landmarks = self.model.forward(


### PR DESCRIPTION
the original repo use a threshold of 0.35 that is appropriate based on my tests. 0.8 is very large and results in many false negatives.

### What has been done

With this PR, the threshold for CenterFace has changed from 0.8 to 0.35.

