### PR TITLE
fastmtcnn's coordinates casted to int

### DIFF
--- a/deepface/models/face_detection/FastMtCnn.py
+++ b/deepface/models/face_detection/FastMtCnn.py
@@ -92,4 +92,4 @@ def xyxy_to_xywh(regions: Union[list, tuple]) -> tuple:
     x, y, x_plus_w, y_plus_h = regions[0], regions[1], regions[2], regions[3]
     w = x_plus_w - x
     h = y_plus_h - y
-    return (x, y, w, h)
+    return (int(x), int(y), int(w), int(h))


### PR DESCRIPTION
## Tickets

Resolves https://github.com/serengil/deepface/issues/1410

### What has been done

With this PR, fast mtcnn's coordinates are casted to int

## How to test

```shell
make lint && make test
```