### PR TITLE
pickle objects are now dumped with pickle.HIGHEST_PROTOCOL

### DIFF
--- a/deepface/modules/recognition.py
+++ b/deepface/modules/recognition.py
@@ -149,7 +149,7 @@ def find(
     # Ensure the proper pickle file exists
     if not os.path.exists(datastore_path):
         with open(datastore_path, "wb") as f:
-            pickle.dump([], f)
+            pickle.dump([], f, pickle.HIGHEST_PROTOCOL)
 
     # Load the representations from the pickle file
     with open(datastore_path, "rb") as f:
@@ -232,7 +232,7 @@ def find(
 
     if must_save_pickle:
         with open(datastore_path, "wb") as f:
-            pickle.dump(representations, f)
+            pickle.dump(representations, f, pickle.HIGHEST_PROTOCOL)
         if not silent:
             logger.info(f"There are now {len(representations)} representations in {file_name}")
 


### PR DESCRIPTION
## Tickets


### What has been done

With this PR, `pickle`'s are now created (`dump`'ed) with `pickle.HIGHEST_PROTOCOL` for the protocol [0]. By using `HIGHEST_PROTOCOL`, python will use the best protocol version given for the system. This can include speed increases as well as filesize reductions.

This will not effect any existing pickles, as mentioned in the description for `pickle.load` [1]:

> The protocol version of the pickle is detected automatically, so no protocol argument is needed.

[0] https://docs.python.org/3/library/pickle.html#pickle.HIGHEST_PROTOCOL
[1] https://docs.python.org/3/library/pickle.html#pickle.load

## How to test

```shell
make lint && make test
```