### PR TITLE
Optimizations for deepface.recognition.find, Optimization and New Iterator Functionality in image_utils

### DIFF
--- a/deepface/commons/image_utils.py
+++ b/deepface/commons/image_utils.py
@@ -1,7 +1,7 @@
 # built-in dependencies
 import os
 import io
-from typing import List, Union, Tuple
+from typing import Generator, List, Union, Tuple
 import hashlib
 import base64
 from pathlib import Path
@@ -33,6 +33,26 @@ def list_images(path: str) -> List[str]:
                     if img.format.lower() in pil_exts:
                         images.append(exact_path)
     return images
+
+
+def yield_images(path: str) -> Generator[str]:
+    """
+    List images in a given path
+    Args:
+        path (str): path's location
+    Yields:
+        image (str): image path
+    """
+    images = []
+    image_exts = {".jpg", ".jpeg", ".png"}
+    pil_exts = {"jpeg", "png"}
+    for r, _, f in os.walk(path):
+        for file in f:
+            if os.path.splitext(file)[1].lower() in image_exts:
+                exact_path = os.path.join(r, file)
+                with Image.open(exact_path) as img:  # lazy
+                    if img.format.lower() in pil_exts:
+                        yield exact_path
 
 
 def find_image_hash(file_path: str) -> str:

--- a/deepface/commons/image_utils.py
+++ b/deepface/commons/image_utils.py
@@ -35,7 +35,7 @@ def list_images(path: str) -> List[str]:
     return images
 
 
-def yield_images(path: str) -> Generator[str]:
+def yield_images(path: str) -> Generator[str, None, None]:
     """
     Yield images in a given path
     Args:

--- a/deepface/commons/image_utils.py
+++ b/deepface/commons/image_utils.py
@@ -43,7 +43,6 @@ def yield_images(path: str) -> Generator[str]:
     Yields:
         image (str): image path
     """
-    images = []
     image_exts = {".jpg", ".jpeg", ".png"}
     pil_exts = {"jpeg", "png"}
     for r, _, f in os.walk(path):

--- a/deepface/commons/image_utils.py
+++ b/deepface/commons/image_utils.py
@@ -23,18 +23,15 @@ def list_images(path: str) -> List[str]:
         images (list): list of exact image paths
     """
     images = []
+    image_exts = {".jpg", ".jpeg", ".png"}
+    pil_exts = {"jpeg", "png"}
     for r, _, f in os.walk(path):
         for file in f:
-            exact_path = os.path.join(r, file)
-
-            ext_lower = os.path.splitext(exact_path)[-1].lower()
-
-            if ext_lower not in {".jpg", ".jpeg", ".png"}:
-                continue
-
-            with Image.open(exact_path) as img:  # lazy
-                if img.format.lower() in {"jpeg", "png"}:
-                    images.append(exact_path)
+            if os.path.splitext(file)[1].lower() in image_exts:
+                exact_path = os.path.join(r, file)
+                with Image.open(exact_path) as img:  # lazy
+                    if img.format.lower() in pil_exts:
+                        images.append(exact_path)
     return images
 
 

--- a/deepface/commons/image_utils.py
+++ b/deepface/commons/image_utils.py
@@ -37,7 +37,7 @@ def list_images(path: str) -> List[str]:
 
 def yield_images(path: str) -> Generator[str]:
     """
-    List images in a given path
+    Yield images in a given path
     Args:
         path (str): path's location
     Yields:

--- a/deepface/modules/recognition.py
+++ b/deepface/modules/recognition.py
@@ -168,7 +168,7 @@ def find(
     pickled_images = [representation["identity"] for representation in representations]
 
     # Get the list of images on storage
-    storage_images = image_utils.list_images(path=db_path)
+    storage_images = set(image_utils.yield_images(path=db_path))
 
     if len(storage_images) == 0 and refresh_database is True:
         raise ValueError(f"No item found in {db_path}")
@@ -186,8 +186,8 @@ def find(
 
     # Enforce data consistency amongst on disk images and pickle file
     if refresh_database:
-        new_images = set(storage_images) - set(pickled_images)  # images added to storage
-        old_images = set(pickled_images) - set(storage_images)  # images removed from storage
+        new_images = storage_images - set(pickled_images)  # images added to storage
+        old_images = set(pickled_images) - storage_images  # images removed from storage
 
         # detect replaced images
         for current_representation in representations:

--- a/deepface/modules/recognition.py
+++ b/deepface/modules/recognition.py
@@ -165,7 +165,7 @@ def find(
             )
 
     # embedded images
-    pickled_images = [representation["identity"] for representation in representations]
+    pickled_images = {representation["identity"] for representation in representations}
 
     # Get the list of images on storage
     storage_images = set(image_utils.yield_images(path=db_path))
@@ -186,8 +186,8 @@ def find(
 
     # Enforce data consistency amongst on disk images and pickle file
     if refresh_database:
-        new_images = storage_images - set(pickled_images)  # images added to storage
-        old_images = set(pickled_images) - storage_images  # images removed from storage
+        new_images = storage_images - pickled_images  # images added to storage
+        old_images = pickled_images - storage_images  # images removed from storage
 
         # detect replaced images
         for current_representation in representations:

--- a/deepface/modules/recognition.py
+++ b/deepface/modules/recognition.py
@@ -136,7 +136,7 @@ def find(
     representations = []
 
     # required columns for representations
-    df_cols = [
+    df_cols = {
         "identity",
         "hash",
         "embedding",
@@ -144,7 +144,7 @@ def find(
         "target_y",
         "target_w",
         "target_h",
-    ]
+    }
 
     # Ensure the proper pickle file exists
     if not os.path.exists(datastore_path):
@@ -157,7 +157,7 @@ def find(
 
     # check each item of representations list has required keys
     for i, current_representation in enumerate(representations):
-        missing_keys = set(df_cols) - set(current_representation.keys())
+        missing_keys = df_cols - set(current_representation.keys())
         if len(missing_keys) > 0:
             raise ValueError(
                 f"{i}-th item does not have some required keys - {missing_keys}."

--- a/deepface/modules/recognition.py
+++ b/deepface/modules/recognition.py
@@ -164,9 +164,6 @@ def find(
                 f"Consider to delete {datastore_path}"
             )
 
-    # embedded images
-    pickled_images = {representation["identity"] for representation in representations}
-
     # Get the list of images on storage
     storage_images = set(image_utils.yield_images(path=db_path))
 
@@ -186,6 +183,11 @@ def find(
 
     # Enforce data consistency amongst on disk images and pickle file
     if refresh_database:
+        # embedded images
+        pickled_images = {
+            representation["identity"] for representation in representations
+        }
+
         new_images = storage_images - pickled_images  # images added to storage
         old_images = pickled_images - storage_images  # images removed from storage
 

--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -95,12 +95,23 @@ def test_filetype_for_find():
 
 
 def test_filetype_for_find_bulk_embeddings():
-    imgs = image_utils.list_images("dataset")
+    # List
+    list_imgs = image_utils.list_images("dataset")
 
-    assert len(imgs) > 0
+    assert len(list_imgs) > 0
 
     # img47 is webp even though its extension is jpg
-    assert "dataset/img47.jpg" not in imgs
+    assert "dataset/img47.jpg" not in list_imgs
+
+    # Generator
+    gen_imgs = list(image_utils.yield_images("dataset"))
+
+    assert len(gen_imgs) > 0
+
+    # img47 is webp even though its extension is jpg
+    assert "dataset/img47.jpg" not in gen_imgs
+
+    assert gen_imgs == list_imgs
 
 
 def test_find_without_refresh_database():


### PR DESCRIPTION
### What has been done

With this PR, I have made optimizations and opinionated changes to `deepface.modules.recognition` as well as `deepface.commons.image_utils`. The optimizations include better use of sets, delayed object creation, and ahead of time creation for set objects used in tight loops.

The modifications proposed in this PR are highly opinionated, so please feel free to request any modifications or to refuse it outright.

### `deepface.commons.image_utils`

#### Modified
`list_images`

- Image and PIL file extensions are now stored in sets built ahead of walking the directory. This prevents new sets from needing to be created on each iteration.
- exact_path is not created unless the file ext is already in image_exts

#### New
`yield_images`

- New generator function
- Mimics the same functionality as `list_images` but yields the exact_path instead of building and returning the list
- Using an iterator will improve speed and reduce memory when created as a set in `deepface.modules.recognition`

&nbsp;


### `deepface.modules.recognition`

#### Modified

- storage_images is now built using the new `deepface.commons.image_utils.yield_images` iterator
- storage_images is created as a set instead of a list, as all operations on it were set operations
- pickled_images is now delayed until `if refresh_database` is True'sh to prevent unnecessary object creation
- pickled_images is now created as a set comprehension instead of a list comprehension, as all operations on it were set operations
- new_images and old_images can now be created without having to convert pickled_images and storage_images into sets
- df_cols is stored as a set. If column order will be necessary in the future, this should be restored to a list

## How to test

The test in `deepface.tests.test_find.test_filetype_for_find_bulk_embeddings` checks the new `deepface.commons.image_utils.yield_images` for functionality and equivalence to the existing `deepface.commons.image_utils.list_images` function.

```shell
make lint && make test
```