### PR TITLE
load_image now accepts file objects that support being read

### DIFF
--- a/deepface/DeepFace.py
+++ b/deepface/DeepFace.py
@@ -85,11 +85,13 @@ def verify(
     Verify if an image pair represents the same person or different persons.
     Args:
         img1_path (str or np.ndarray or IO[bytes] or List[float]): Path to the first image.
-            Accepts exact image path as a string, numpy array (BGR), base64 encoded images
+            Accepts exact image path as a string, numpy array (BGR), a file object that supports
+            at least `.read` and is opened in binary mode, base64 encoded images
             or pre-calculated embeddings.
 
         img2_path (str or np.ndarray or IO[bytes] or List[float]): Path to the second image.
-            Accepts exact image path as a string, numpy array (BGR), base64 encoded images
+            Accepts exact image path as a string, numpy array (BGR), a file object that supports
+            at least `.read` and is opened in binary mode, base64 encoded images
             or pre-calculated embeddings.
 
         model_name (str): Model for face recognition. Options: VGG-Face, Facenet, Facenet512,
@@ -177,7 +179,8 @@ def analyze(
     Analyze facial attributes such as age, gender, emotion, and race in the provided image.
     Args:
         img_path (str or np.ndarray or IO[bytes]): The exact path to the image, a numpy array
-            in BGR format, or a base64 encoded image. If the source image contains multiple faces,
+            in BGR format, a file object that supports at least `.read` and is opened in binary
+            mode, or a base64 encoded image. If the source image contains multiple faces,
             the result will include information for each detected face.
 
         actions (tuple): Attributes to analyze. The default is ('age', 'gender', 'emotion', 'race').
@@ -282,7 +285,8 @@ def find(
     Identify individuals in a database
     Args:
         img_path (str or np.ndarray or IO[bytes]): The exact path to the image, a numpy array
-            in BGR format, or a base64 encoded image. If the source image contains multiple
+            in BGR format, a file object that supports at least `.read` and is opened in binary
+            mode, or a base64 encoded image. If the source image contains multiple
             faces, the result will include information for each detected face.
 
         db_path (string): Path to the folder containing image files. All detected faces
@@ -384,7 +388,8 @@ def represent(
 
     Args:
         img_path (str or np.ndarray or IO[bytes]): The exact path to the image, a numpy array
-            in BGR format, or a base64 encoded image. If the source image contains multiple faces,
+            in BGR format, a file object that supports at least `.read` and is opened in binary
+            mode, or a base64 encoded image. If the source image contains multiple faces,
             the result will include information for each detected face.
 
         model_name (str): Model for face recognition. Options: VGG-Face, Facenet, Facenet512,
@@ -520,7 +525,8 @@ def extract_faces(
 
     Args:
         img_path (str or np.ndarray or IO[bytes]): Path to the first image. Accepts exact image path
-            as a string, numpy array (BGR), or base64 encoded images.
+            as a string, numpy array (BGR), a file object that supports at least `.read` and is
+            opened in binary mode, or base64 encoded images.
 
         detector_backend (string): face detector backend. Options: 'opencv', 'retinaface',
             'mtcnn', 'ssd', 'dlib', 'mediapipe', 'yolov8', 'yolov11n', 'yolov11s', 'yolov11m',

--- a/deepface/DeepFace.py
+++ b/deepface/DeepFace.py
@@ -176,9 +176,9 @@ def analyze(
     """
     Analyze facial attributes such as age, gender, emotion, and race in the provided image.
     Args:
-        img_path (str or np.ndarray or IO[bytes]): The exact path to the image, a numpy array in BGR format,
-            or a base64 encoded image. If the source image contains multiple faces, the result will
-            include information for each detected face.
+        img_path (str or np.ndarray or IO[bytes]): The exact path to the image, a numpy array
+            in BGR format, or a base64 encoded image. If the source image contains multiple faces,
+            the result will include information for each detected face.
 
         actions (tuple): Attributes to analyze. The default is ('age', 'gender', 'emotion', 'race').
             You can exclude some of these attributes from the analysis if needed.
@@ -281,9 +281,9 @@ def find(
     """
     Identify individuals in a database
     Args:
-        img_path (str or np.ndarray or IO[bytes]): The exact path to the image, a numpy array in BGR format,
-            or a base64 encoded image. If the source image contains multiple faces, the result will
-            include information for each detected face.
+        img_path (str or np.ndarray or IO[bytes]): The exact path to the image, a numpy array
+            in BGR format, or a base64 encoded image. If the source image contains multiple
+            faces, the result will include information for each detected face.
 
         db_path (string): Path to the folder containing image files. All detected faces
             in the database will be considered in the decision-making process.
@@ -383,9 +383,9 @@ def represent(
     Represent facial images as multi-dimensional vector embeddings.
 
     Args:
-        img_path (str or np.ndarray or IO[bytes]): The exact path to the image, a numpy array in BGR format,
-            or a base64 encoded image. If the source image contains multiple faces, the result will
-            include information for each detected face.
+        img_path (str or np.ndarray or IO[bytes]): The exact path to the image, a numpy array
+            in BGR format, or a base64 encoded image. If the source image contains multiple faces,
+            the result will include information for each detected face.
 
         model_name (str): Model for face recognition. Options: VGG-Face, Facenet, Facenet512,
             OpenFace, DeepFace, DeepID, Dlib, ArcFace, SFace and GhostFaceNet

--- a/deepface/DeepFace.py
+++ b/deepface/DeepFace.py
@@ -84,11 +84,11 @@ def verify(
     """
     Verify if an image pair represents the same person or different persons.
     Args:
-        img1_path (str or np.ndarray or List[float]): Path to the first image.
+        img1_path (str or np.ndarray or IO[bytes] or List[float]): Path to the first image.
             Accepts exact image path as a string, numpy array (BGR), base64 encoded images
             or pre-calculated embeddings.
 
-        img2_path (str or np.ndarray or List[float]): Path to the second image.
+        img2_path (str or np.ndarray or IO[bytes] or List[float]): Path to the second image.
             Accepts exact image path as a string, numpy array (BGR), base64 encoded images
             or pre-calculated embeddings.
 
@@ -176,7 +176,7 @@ def analyze(
     """
     Analyze facial attributes such as age, gender, emotion, and race in the provided image.
     Args:
-        img_path (str or np.ndarray): The exact path to the image, a numpy array in BGR format,
+        img_path (str or np.ndarray or IO[bytes]): The exact path to the image, a numpy array in BGR format,
             or a base64 encoded image. If the source image contains multiple faces, the result will
             include information for each detected face.
 
@@ -281,7 +281,7 @@ def find(
     """
     Identify individuals in a database
     Args:
-        img_path (str or np.ndarray): The exact path to the image, a numpy array in BGR format,
+        img_path (str or np.ndarray or IO[bytes]): The exact path to the image, a numpy array in BGR format,
             or a base64 encoded image. If the source image contains multiple faces, the result will
             include information for each detected face.
 
@@ -383,7 +383,7 @@ def represent(
     Represent facial images as multi-dimensional vector embeddings.
 
     Args:
-        img_path (str or np.ndarray): The exact path to the image, a numpy array in BGR format,
+        img_path (str or np.ndarray or IO[bytes]): The exact path to the image, a numpy array in BGR format,
             or a base64 encoded image. If the source image contains multiple faces, the result will
             include information for each detected face.
 
@@ -519,7 +519,7 @@ def extract_faces(
     Extract faces from a given image
 
     Args:
-        img_path (str or np.ndarray): Path to the first image. Accepts exact image path
+        img_path (str or np.ndarray or IO[bytes]): Path to the first image. Accepts exact image path
             as a string, numpy array (BGR), or base64 encoded images.
 
         detector_backend (string): face detector backend. Options: 'opencv', 'retinaface',

--- a/deepface/DeepFace.py
+++ b/deepface/DeepFace.py
@@ -2,7 +2,7 @@
 import os
 import warnings
 import logging
-from typing import Any, Dict, List, Union, Optional
+from typing import Any, Dict, IO, List, Union, Optional
 
 # this has to be set before importing tensorflow
 os.environ["TF_USE_LEGACY_KERAS"] = "1"
@@ -68,8 +68,8 @@ def build_model(model_name: str, task: str = "facial_recognition") -> Any:
 
 
 def verify(
-    img1_path: Union[str, np.ndarray, List[float]],
-    img2_path: Union[str, np.ndarray, List[float]],
+    img1_path: Union[str, np.ndarray, IO[bytes], List[float]],
+    img2_path: Union[str, np.ndarray, IO[bytes], List[float]],
     model_name: str = "VGG-Face",
     detector_backend: str = "opencv",
     distance_metric: str = "cosine",
@@ -164,7 +164,7 @@ def verify(
 
 
 def analyze(
-    img_path: Union[str, np.ndarray],
+    img_path: Union[str, np.ndarray, IO[bytes]],
     actions: Union[tuple, list] = ("emotion", "age", "gender", "race"),
     enforce_detection: bool = True,
     detector_backend: str = "opencv",
@@ -263,7 +263,7 @@ def analyze(
 
 
 def find(
-    img_path: Union[str, np.ndarray],
+    img_path: Union[str, np.ndarray, IO[bytes]],
     db_path: str,
     model_name: str = "VGG-Face",
     distance_metric: str = "cosine",
@@ -369,7 +369,7 @@ def find(
 
 
 def represent(
-    img_path: Union[str, np.ndarray],
+    img_path: Union[str, np.ndarray, IO[bytes]],
     model_name: str = "VGG-Face",
     enforce_detection: bool = True,
     detector_backend: str = "opencv",
@@ -505,7 +505,7 @@ def stream(
 
 
 def extract_faces(
-    img_path: Union[str, np.ndarray],
+    img_path: Union[str, np.ndarray, IO[bytes]],
     detector_backend: str = "opencv",
     enforce_detection: bool = True,
     align: bool = True,

--- a/deepface/commons/image_utils.py
+++ b/deepface/commons/image_utils.py
@@ -1,7 +1,7 @@
 # built-in dependencies
 import os
 import io
-from typing import IO, Generator, List, Union, Tuple
+from typing import Generator, IO, List, Union, Tuple
 import hashlib
 import base64
 from pathlib import Path

--- a/deepface/commons/image_utils.py
+++ b/deepface/commons/image_utils.py
@@ -146,6 +146,8 @@ def load_image_from_io_object(obj: IO[bytes]) -> np.ndarray:
     try:
         nparr = np.frombuffer(obj.read(), np.uint8)
         img = cv2.imdecode(nparr, cv2.IMREAD_COLOR)
+        if img is None:
+            raise ValueError("Failed to decode image")
         return img
     finally:
         if not seekable:

--- a/deepface/modules/detection.py
+++ b/deepface/modules/detection.py
@@ -34,7 +34,7 @@ def extract_faces(
     Extract faces from a given image
 
     Args:
-        img_path (str or np.ndarray): Path to the first image. Accepts exact image path
+        img_path (str or np.ndarray or IO[bytes]): Path to the first image. Accepts exact image path
             as a string, numpy array (BGR), or base64 encoded images.
 
         detector_backend (string): face detector backend. Options: 'opencv', 'retinaface',

--- a/deepface/modules/detection.py
+++ b/deepface/modules/detection.py
@@ -35,7 +35,8 @@ def extract_faces(
 
     Args:
         img_path (str or np.ndarray or IO[bytes]): Path to the first image. Accepts exact image path
-            as a string, numpy array (BGR), or base64 encoded images.
+            as a string, numpy array (BGR), a file object that supports at least `.read` and is
+            opened in binary mode, or base64 encoded images.
 
         detector_backend (string): face detector backend. Options: 'opencv', 'retinaface',
             'mtcnn', 'ssd', 'dlib', 'mediapipe', 'yolov8', 'yolov11n', 'yolov11s', 'yolov11m',

--- a/deepface/modules/detection.py
+++ b/deepface/modules/detection.py
@@ -1,5 +1,5 @@
 # built-in dependencies
-from typing import Any, Dict, List, Tuple, Union, Optional
+from typing import Any, Dict, IO, List, Tuple, Union, Optional
 
 # 3rd part dependencies
 from heapq import nlargest
@@ -19,7 +19,7 @@ logger = Logger()
 
 
 def extract_faces(
-    img_path: Union[str, np.ndarray],
+    img_path: Union[str, np.ndarray, IO[bytes]],
     detector_backend: str = "opencv",
     enforce_detection: bool = True,
     align: bool = True,

--- a/tests/test_represent.py
+++ b/tests/test_represent.py
@@ -1,4 +1,5 @@
 # built-in dependencies
+import io
 import cv2
 
 # project dependencies
@@ -16,6 +17,21 @@ def test_standard_represent():
         logger.debug(f"Function returned {len(embedding)} dimensional vector")
         assert len(embedding) == 4096
     logger.info("✅ test standard represent function done")
+
+
+def test_standard_represent_with_io_object():
+    img_path = "dataset/img1.jpg"
+    defualt_embedding_objs = DeepFace.represent(img_path)
+    io_embedding_objs = DeepFace.represent(open(img_path, 'rb'))
+    assert defualt_embedding_objs == io_embedding_objs
+
+    # Confirm non-seekable io objects are handled properly
+    io_obj = io.BytesIO(open(img_path, 'rb').read())
+    io_obj.seek = None
+    no_seek_io_embedding_objs = DeepFace.represent(io_obj)
+    assert defualt_embedding_objs == no_seek_io_embedding_objs
+
+    logger.info("✅ test standard represent with io object function done")
 
 
 def test_represent_for_skipped_detector_backend_with_image_path():

--- a/tests/test_represent.py
+++ b/tests/test_represent.py
@@ -1,6 +1,7 @@
 # built-in dependencies
 import io
 import cv2
+import pytest
 
 # project dependencies
 from deepface import DeepFace
@@ -30,6 +31,10 @@ def test_standard_represent_with_io_object():
     io_obj.seek = None
     no_seek_io_embedding_objs = DeepFace.represent(io_obj)
     assert default_embedding_objs == no_seek_io_embedding_objs
+
+    # Confirm non-image io objects raise exceptions
+    with pytest.raises(ValueError, match='Failed to decode image'):
+        DeepFace.represent(io.BytesIO(open(__file__, 'rb').read()))
 
     logger.info("✅ test standard represent with io object function done")
 

--- a/tests/test_represent.py
+++ b/tests/test_represent.py
@@ -21,15 +21,15 @@ def test_standard_represent():
 
 def test_standard_represent_with_io_object():
     img_path = "dataset/img1.jpg"
-    defualt_embedding_objs = DeepFace.represent(img_path)
+    default_embedding_objs = DeepFace.represent(img_path)
     io_embedding_objs = DeepFace.represent(open(img_path, 'rb'))
-    assert defualt_embedding_objs == io_embedding_objs
+    assert default_embedding_objs == io_embedding_objs
 
     # Confirm non-seekable io objects are handled properly
     io_obj = io.BytesIO(open(img_path, 'rb').read())
     io_obj.seek = None
     no_seek_io_embedding_objs = DeepFace.represent(io_obj)
-    assert defualt_embedding_objs == no_seek_io_embedding_objs
+    assert default_embedding_objs == no_seek_io_embedding_objs
 
     logger.info("✅ test standard represent with io object function done")
 

--- a/tests/test_represent.py
+++ b/tests/test_represent.py
@@ -34,7 +34,7 @@ def test_standard_represent_with_io_object():
 
     # Confirm non-image io objects raise exceptions
     with pytest.raises(ValueError, match='Failed to decode image'):
-        DeepFace.represent(io.BytesIO(open(__file__, 'rb').read()))
+        DeepFace.represent(io.BytesIO(open(r'../requirements.txt', 'rb').read()))
 
     logger.info("✅ test standard represent with io object function done")
 


### PR DESCRIPTION
### What has been done

With this PR, `deepface.commons.image_utils.load_image` now accepts file objects that support being read.

Objects that support being read but not seeked are handled by reading the data into a new `io.BytesIO` object which is automatically closed before returning the data or raising an exception.

## Examples of new functionalities are...

### PIL Image

Below is an example of opening a `PIL.Image` in memory, rotating the image, writing the modified image to an in-memory `io.BytesIO` object, and then performing a `DeepFace.represent` calculation on the in-memory object.

Modifications of this ilk could be converting images to greyscale, resizing, cropping, etc., all done in memory while not having to constantly write to disk.

```python3
from deepface import DeepFace
from PIL import Image

representations = []
with Image.open(r'/path/to/image.png') as img:
    for rotation in range(4):
        pil_io = io.BytesIO()
        rotated_img = img.rotate(rotation * 90)
        rotated_img.save(pil_io, format='PNG')
        rp = DeepFace.represent(pil_io, enforce_detection=False)
        representations.append(rp)
        pil_io.close()
```

#### Streaming object

I know `deepface.commons.image_utils.load_image` already accepts a URL as a string but it can be more convenient to control how the request is made yourself than by the library, i.e., allowing redirects, controlling timeout, handling tokens with Sessions,  etc.

```python3
import requests

from deepface import DeepFace

r = requests.get('https://raw.githubusercontent.com/serengil/deepface/refs/heads/master/tests/dataset/img1.jpg', stream=True)
r.raise_for_status()
representations = DeepFace.represent(r.raw)
```

#### As a File Object

```python3
with open(r'/path/to/image.png', 'rb') as f:
    representation = DeepFace.represent(f)
```

or

```python3
representation = DeepFace.represent(open(r'/path/to/image.png', 'rb'))
```

This functionality, while already provided by passing the filepath as a string, closer mirrors the functionality of other Python libraries, such as how `json.load`[0], `pickle.load`[1] and `PIL.Image.open`[2] operate.

#### From a ZipArchive

```python3
from zipfile import ZipFile

with ZipFile('some_archive.zip') as z:
    with z.open(r'/path/to/image.png') as f:
        representation = DeepFace.represent(f)
```


[0] https://docs.python.org/3/library/json.html#json.load
[1] https://docs.python.org/3/library/pickle.html#pickle.load
[2] https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.open


## How to test

A new test at `deepface.tests.test_represent.test_standard_represent_with_io_object` has been created to ensure representations loaded with the new `deepface.commons.image_utils.load_image_from_io_object` are identical to the default implementation. The new test also ensures objects that do not support `seek`, e.g., streaming objects, are also properly handled and supported.

```shell
make lint && make test
```