### PR TITLE
Batching on `.extract_faces` to improve performance and utilize GPU in full

### DIFF
--- a/deepface/DeepFace.py
+++ b/deepface/DeepFace.py
@@ -519,7 +519,7 @@ def extract_faces(
     color_face: str = "rgb",
     normalize_face: bool = True,
     anti_spoofing: bool = False,
-) -> List[Dict[str, Any]]:
+) -> Union[List[Dict[str, Any]], List[List[Dict[str, Any]]]]:
     """
     Extract faces from a given image or sequence of images.
 
@@ -551,7 +551,8 @@ def extract_faces(
         anti_spoofing (boolean): Flag to enable anti spoofing (default is False).
 
     Returns:
-        results (List[Dict[str, Any]]): A list of dictionaries, where each dictionary contains:
+        results (Union[List[Dict[str, Any]], List[List[Dict[str, Any]]]): 
+        A list or a list of lists of dictionaries, where each dictionary contains:
 
         - "face" (np.ndarray): The detected face as a NumPy array.
 

--- a/deepface/DeepFace.py
+++ b/deepface/DeepFace.py
@@ -2,7 +2,7 @@
 import os
 import warnings
 import logging
-from typing import Any, Dict, IO, List, Union, Optional
+from typing import Any, Dict, IO, List, Union, Optional, Sequence
 
 # this has to be set before importing tensorflow
 os.environ["TF_USE_LEGACY_KERAS"] = "1"
@@ -510,7 +510,7 @@ def stream(
 
 
 def extract_faces(
-    img_path: Union[str, np.ndarray, IO[bytes]],
+    img_path: Union[str, np.ndarray, IO[bytes], Sequence[Union[str, np.ndarray, IO[bytes]]]],
     detector_backend: str = "opencv",
     enforce_detection: bool = True,
     align: bool = True,
@@ -521,12 +521,12 @@ def extract_faces(
     anti_spoofing: bool = False,
 ) -> List[Dict[str, Any]]:
     """
-    Extract faces from a given image
+    Extract faces from a given image or sequence of images.
 
     Args:
-        img_path (str or np.ndarray or IO[bytes]): Path to the first image. Accepts exact image path
-            as a string, numpy array (BGR), a file object that supports at least `.read` and is
-            opened in binary mode, or base64 encoded images.
+        img_path (Union[str, np.ndarray, IO[bytes], Sequence[Union[str, np.ndarray, IO[bytes]]]]): 
+            Path(s) to the image(s). Accepts a string path, a numpy array (BGR), a file object 
+            that supports at least `.read` and is opened in binary mode, or base64 encoded images.
 
         detector_backend (string): face detector backend. Options: 'opencv', 'retinaface',
             'mtcnn', 'ssd', 'dlib', 'mediapipe', 'yolov8', 'yolov11n', 'yolov11s', 'yolov11m',

--- a/deepface/models/Detector.py
+++ b/deepface/models/Detector.py
@@ -1,7 +1,36 @@
 from typing import List, Tuple, Optional, Union
-from abc import ABC
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 import numpy as np
+
+# Notice that all facial detector models must be inherited from this class
+
+
+# pylint: disable=unnecessary-pass, too-few-public-methods, too-many-instance-attributes
+class Detector(ABC):
+    @abstractmethod
+    def detect_faces(
+        self,
+        img: Union[np.ndarray, List[np.ndarray]]
+    ) -> Union[List["FacialAreaRegion"], List[List["FacialAreaRegion"]]]:
+        """
+        Interface for detect and align faces in a batch of images
+
+        Args:
+            img (Union[np.ndarray, List[np.ndarray]]): 
+            Pre-loaded image as numpy array or a list of those
+
+        Returns:
+            results (Union[List[List[FacialAreaRegion]], List[FacialAreaRegion]]): 
+            A list or a list of lists of FacialAreaRegion objects
+                where each object contains:
+
+            - facial_area (FacialAreaRegion): The facial area region represented
+                as x, y, w, h, left_eye and right_eye. left eye and right eye are
+                eyes on the left and right respectively with respect to the person
+                instead of observer.
+        """
+        pass
 
 
 # pylint: disable=unnecessary-pass, too-few-public-methods, too-many-instance-attributes
@@ -49,56 +78,3 @@ class DetectedFace:
     img: np.ndarray
     facial_area: FacialAreaRegion
     confidence: float
-
-
-# Notice that all facial detector models must be inherited from this class
-
-class Detector(ABC):
-
-    def detect_faces(
-        self,
-        img: Union[np.ndarray, List[np.ndarray]],
-    ) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
-        """
-        Detect and align faces in an image or a list of images
-
-        Args:
-            img (Union[np.ndarray, List[np.ndarray]]): 
-            pre-loaded image as numpy array or a list of those
-
-        Returns:
-            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): 
-            A list or a list of lists of FacialAreaRegion objects
-        """
-        is_batched_input = isinstance(img, list)
-        if not is_batched_input:
-            img = [img]
-        results = [self._process_single_image(single_img) for single_img in img]
-        if not is_batched_input:
-            return results[0]
-        return results
-
-    def _process_single_image(
-        self,
-        img: np.ndarray
-    ) -> List[FacialAreaRegion]:
-        """
-        Interface for detect and align faces in a single image
-
-        Args:
-            img (Union[np.ndarray, List[np.ndarray]]): 
-            Pre-loaded image as numpy array or a list of those
-
-        Returns:
-            results (Union[List[List[FacialAreaRegion]], List[FacialAreaRegion]]): 
-            A list or a list of lists of FacialAreaRegion objects
-                where each object contains:
-
-            - facial_area (FacialAreaRegion): The facial area region represented
-                as x, y, w, h, left_eye and right_eye. left eye and right eye are
-                eyes on the left and right respectively with respect to the person
-                instead of observer.
-        """
-        raise NotImplementedError(
-            "Subclasses that do not implement batch detection must implement this method"
-        )

--- a/deepface/models/Detector.py
+++ b/deepface/models/Detector.py
@@ -10,14 +10,15 @@ import numpy as np
 class Detector(ABC):
     @abstractmethod
     def detect_faces(
-        self, 
-        imgs: Union[np.ndarray, List[np.ndarray]]
+        self,
+        img: Union[np.ndarray, List[np.ndarray]]
     ) -> Union[List["FacialAreaRegion"], List[List["FacialAreaRegion"]]]:
         """
         Interface for detect and align faces in a batch of images
 
         Args:
-            imgs (Union[np.ndarray, List[np.ndarray]]): pre-loaded image as numpy array or a list of those
+            img (Union[np.ndarray, List[np.ndarray]]): 
+            Pre-loaded image as numpy array or a list of those
 
         Returns:
             results (Union[List[List[FacialAreaRegion]], List[FacialAreaRegion]]): 

--- a/deepface/models/Detector.py
+++ b/deepface/models/Detector.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 import numpy as np
 
 
+# pylint: disable=unnecessary-pass, too-few-public-methods, too-many-instance-attributes
 @dataclass
 class FacialAreaRegion:
     """
@@ -52,7 +53,6 @@ class DetectedFace:
 
 # Notice that all facial detector models must be inherited from this class
 
-# pylint: disable=unnecessary-pass, too-few-public-methods, too-many-instance-attributes
 class Detector(ABC):
 
     def detect_faces(

--- a/deepface/models/Detector.py
+++ b/deepface/models/Detector.py
@@ -1,36 +1,7 @@
 from typing import List, Tuple, Optional, Union
-from abc import ABC, abstractmethod
+from abc import ABC
 from dataclasses import dataclass
 import numpy as np
-
-# Notice that all facial detector models must be inherited from this class
-
-
-# pylint: disable=unnecessary-pass, too-few-public-methods, too-many-instance-attributes
-class Detector(ABC):
-    @abstractmethod
-    def detect_faces(
-        self,
-        img: Union[np.ndarray, List[np.ndarray]]
-    ) -> Union[List["FacialAreaRegion"], List[List["FacialAreaRegion"]]]:
-        """
-        Interface for detect and align faces in a batch of images
-
-        Args:
-            img (Union[np.ndarray, List[np.ndarray]]): 
-            Pre-loaded image as numpy array or a list of those
-
-        Returns:
-            results (Union[List[List[FacialAreaRegion]], List[FacialAreaRegion]]): 
-            A list or a list of lists of FacialAreaRegion objects
-                where each object contains:
-
-            - facial_area (FacialAreaRegion): The facial area region represented
-                as x, y, w, h, left_eye and right_eye. left eye and right eye are
-                eyes on the left and right respectively with respect to the person
-                instead of observer.
-        """
-        pass
 
 
 @dataclass
@@ -77,3 +48,57 @@ class DetectedFace:
     img: np.ndarray
     facial_area: FacialAreaRegion
     confidence: float
+
+
+# Notice that all facial detector models must be inherited from this class
+
+# pylint: disable=unnecessary-pass, too-few-public-methods, too-many-instance-attributes
+class Detector(ABC):
+
+    def detect_faces(
+        self,
+        img: Union[np.ndarray, List[np.ndarray]],
+    ) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
+        """
+        Detect and align faces in an image or a list of images
+
+        Args:
+            img (Union[np.ndarray, List[np.ndarray]]): 
+            pre-loaded image as numpy array or a list of those
+
+        Returns:
+            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): 
+            A list or a list of lists of FacialAreaRegion objects
+        """
+        is_batched_input = isinstance(img, list)
+        if not is_batched_input:
+            img = [img]
+        results = [self._process_single_image(single_img) for single_img in img]
+        if not is_batched_input:
+            return results[0]
+        return results
+
+    def _process_single_image(
+        self,
+        img: np.ndarray
+    ) -> List[FacialAreaRegion]:
+        """
+        Interface for detect and align faces in a single image
+
+        Args:
+            img (Union[np.ndarray, List[np.ndarray]]): 
+            Pre-loaded image as numpy array or a list of those
+
+        Returns:
+            results (Union[List[List[FacialAreaRegion]], List[FacialAreaRegion]]): 
+            A list or a list of lists of FacialAreaRegion objects
+                where each object contains:
+
+            - facial_area (FacialAreaRegion): The facial area region represented
+                as x, y, w, h, left_eye and right_eye. left eye and right eye are
+                eyes on the left and right respectively with respect to the person
+                instead of observer.
+        """
+        raise NotImplementedError(
+            "Subclasses that do not implement batch detection must implement this method"
+        )

--- a/deepface/models/Detector.py
+++ b/deepface/models/Detector.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Optional
+from typing import List, Tuple, Optional, Union
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 import numpy as np
@@ -9,15 +9,19 @@ import numpy as np
 # pylint: disable=unnecessary-pass, too-few-public-methods, too-many-instance-attributes
 class Detector(ABC):
     @abstractmethod
-    def detect_faces(self, img: np.ndarray) -> List["FacialAreaRegion"]:
+    def detect_faces(
+        self, 
+        imgs: Union[np.ndarray, List[np.ndarray]]
+    ) -> Union[List["FacialAreaRegion"], List[List["FacialAreaRegion"]]]:
         """
-        Interface for detect and align face
+        Interface for detect and align faces in a batch of images
 
         Args:
-            img (np.ndarray): pre-loaded image as numpy array
+            imgs (Union[np.ndarray, List[np.ndarray]]): pre-loaded image as numpy array or a list of those
 
         Returns:
-            results (List[FacialAreaRegion]): A list of FacialAreaRegion objects
+            results (Union[List[List[FacialAreaRegion]], List[FacialAreaRegion]]): 
+            A list or a list of lists of FacialAreaRegion objects
                 where each object contains:
 
             - facial_area (FacialAreaRegion): The facial area region represented

--- a/deepface/models/face_detection/CenterFace.py
+++ b/deepface/models/face_detection/CenterFace.py
@@ -49,10 +49,11 @@ class CenterFaceClient(Detector):
             results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): 
             A list or a list of lists of FacialAreaRegion objects
         """
-        if not isinstance(img, list):
+        is_batched_input = isinstance(img, list)
+        if not is_batched_input:
             img = [img]
         results = [self._process_single_image(single_img) for single_img in img]
-        if len(results) == 1:
+        if not is_batched_input:
             return results[0]
         return results
 

--- a/deepface/models/face_detection/CenterFace.py
+++ b/deepface/models/face_detection/CenterFace.py
@@ -34,15 +34,20 @@ class CenterFaceClient(Detector):
 
         return CenterFace(weight_path=weights_path)
 
-    def detect_faces(self, img: Union[np.ndarray, List[np.ndarray]]) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
+    def detect_faces(
+        self, 
+        img: Union[np.ndarray, List[np.ndarray]],
+    ) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
         """
         Detect and align face with CenterFace
 
         Args:
-            img (Union[np.ndarray, List[np.ndarray]]): pre-loaded image as numpy array or a list of those
+            img (Union[np.ndarray, List[np.ndarray]]): 
+            pre-loaded image as numpy array or a list of those
 
         Returns:
-            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): A list or a list of lists of FacialAreaRegion objects
+            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): 
+            A list or a list of lists of FacialAreaRegion objects
         """
         if not isinstance(img, list):
             img = [img]

--- a/deepface/models/face_detection/CenterFace.py
+++ b/deepface/models/face_detection/CenterFace.py
@@ -44,12 +44,12 @@ class CenterFaceClient(Detector):
         Returns:
             results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): A list or a list of lists of FacialAreaRegion objects
         """
-        if isinstance(img, np.ndarray):
-            return self._process_single_image(img)
-        elif isinstance(img, list):
-            return [self._process_single_image(single_img) for single_img in img]
-        else:
-            raise ValueError("Input must be a numpy array or a list of numpy arrays.")
+        if not isinstance(img, list):
+            img = [img]
+        results = [self._process_single_image(single_img) for single_img in img]
+        if len(results) == 1:
+            return results[0]
+        return results
 
     def _process_single_image(self, single_img: np.ndarray) -> List[FacialAreaRegion]:
         """

--- a/deepface/models/face_detection/CenterFace.py
+++ b/deepface/models/face_detection/CenterFace.py
@@ -1,6 +1,6 @@
 # built-in dependencies
 import os
-from typing import List
+from typing import List, Union
 
 # 3rd party dependencies
 import numpy as np
@@ -34,12 +34,29 @@ class CenterFaceClient(Detector):
 
         return CenterFace(weight_path=weights_path)
 
-    def detect_faces(self, img: np.ndarray) -> List["FacialAreaRegion"]:
+    def detect_faces(self, img: Union[np.ndarray, List[np.ndarray]]) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
         """
         Detect and align face with CenterFace
 
         Args:
-            img (np.ndarray): pre-loaded image as numpy array
+            img (Union[np.ndarray, List[np.ndarray]]): pre-loaded image as numpy array or a list of those
+
+        Returns:
+            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): A list or a list of lists of FacialAreaRegion objects
+        """
+        if isinstance(img, np.ndarray):
+            return self._process_single_image(img)
+        elif isinstance(img, list):
+            return [self._process_single_image(single_img) for single_img in img]
+        else:
+            raise ValueError("Input must be a numpy array or a list of numpy arrays.")
+
+    def _process_single_image(self, single_img: np.ndarray) -> List[FacialAreaRegion]:
+        """
+        Helper function to detect faces in a single image.
+
+        Args:
+            single_img (np.ndarray): pre-loaded image as numpy array
 
         Returns:
             results (List[FacialAreaRegion]): A list of FacialAreaRegion objects
@@ -53,7 +70,7 @@ class CenterFaceClient(Detector):
         #     img, img.shape[0], img.shape[1], threshold=threshold
         # )
         detections, landmarks = self.build_model().forward(
-            img, img.shape[0], img.shape[1], threshold=threshold
+            single_img, single_img.shape[0], single_img.shape[1], threshold=threshold
         )
 
         for i, detection in enumerate(detections):

--- a/deepface/models/face_detection/CenterFace.py
+++ b/deepface/models/face_detection/CenterFace.py
@@ -1,6 +1,6 @@
 # built-in dependencies
 import os
-from typing import List, Union
+from typing import List
 
 # 3rd party dependencies
 import numpy as np
@@ -34,35 +34,12 @@ class CenterFaceClient(Detector):
 
         return CenterFace(weight_path=weights_path)
 
-    def detect_faces(
-        self,
-        img: Union[np.ndarray, List[np.ndarray]],
-    ) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
-        """
-        Detect and align face with CenterFace
-
-        Args:
-            img (Union[np.ndarray, List[np.ndarray]]): 
-            pre-loaded image as numpy array or a list of those
-
-        Returns:
-            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): 
-            A list or a list of lists of FacialAreaRegion objects
-        """
-        is_batched_input = isinstance(img, list)
-        if not is_batched_input:
-            img = [img]
-        results = [self._process_single_image(single_img) for single_img in img]
-        if not is_batched_input:
-            return results[0]
-        return results
-
-    def _process_single_image(self, single_img: np.ndarray) -> List[FacialAreaRegion]:
+    def _process_single_image(self, img: np.ndarray) -> List[FacialAreaRegion]:
         """
         Helper function to detect faces in a single image.
 
         Args:
-            single_img (np.ndarray): pre-loaded image as numpy array
+            img (np.ndarray): pre-loaded image as numpy array
 
         Returns:
             results (List[FacialAreaRegion]): A list of FacialAreaRegion objects
@@ -76,7 +53,7 @@ class CenterFaceClient(Detector):
         #     img, img.shape[0], img.shape[1], threshold=threshold
         # )
         detections, landmarks = self.build_model().forward(
-            single_img, single_img.shape[0], single_img.shape[1], threshold=threshold
+            img, img.shape[0], img.shape[1], threshold=threshold
         )
 
         for i, detection in enumerate(detections):

--- a/deepface/models/face_detection/CenterFace.py
+++ b/deepface/models/face_detection/CenterFace.py
@@ -35,7 +35,7 @@ class CenterFaceClient(Detector):
         return CenterFace(weight_path=weights_path)
 
     def detect_faces(
-        self, 
+        self,
         img: Union[np.ndarray, List[np.ndarray]],
     ) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
         """

--- a/deepface/models/face_detection/Dlib.py
+++ b/deepface/models/face_detection/Dlib.py
@@ -47,15 +47,20 @@ class DlibClient(Detector):
         detector["sp"] = sp
         return detector
 
-    def detect_faces(self, img: Union[np.ndarray, List[np.ndarray]]) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
+    def detect_faces(
+        self,
+        img: Union[np.ndarray, List[np.ndarray]],
+    ) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
         """
         Detect and align face with dlib
 
         Args:
-            img (Union[np.ndarray, List[np.ndarray]]): pre-loaded image as numpy array or a list of those
+            img (Union[np.ndarray, List[np.ndarray]]): 
+            pre-loaded image as numpy array or a list of those
 
         Returns:
-            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): A list or a list of lists of FacialAreaRegion objects
+            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): 
+            A list or a list of lists of FacialAreaRegion objects
         """
         if not isinstance(img, list):
             img = [img]

--- a/deepface/models/face_detection/Dlib.py
+++ b/deepface/models/face_detection/Dlib.py
@@ -1,5 +1,5 @@
 # built-in dependencies
-from typing import List, Union
+from typing import List
 
 # 3rd party dependencies
 import numpy as np
@@ -46,29 +46,6 @@ class DlibClient(Detector):
         detector["face_detector"] = face_detector
         detector["sp"] = sp
         return detector
-
-    def detect_faces(
-        self,
-        img: Union[np.ndarray, List[np.ndarray]],
-    ) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
-        """
-        Detect and align face with dlib
-
-        Args:
-            img (Union[np.ndarray, List[np.ndarray]]): 
-            pre-loaded image as numpy array or a list of those
-
-        Returns:
-            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): 
-            A list or a list of lists of FacialAreaRegion objects
-        """
-        is_batched_input = isinstance(img, list)
-        if not is_batched_input:
-            img = [img]
-        results = [self._process_single_image(single_img) for single_img in img]
-        if not is_batched_input:
-            return results[0]
-        return results
 
     def _process_single_image(self, img: np.ndarray) -> List[FacialAreaRegion]:
         """

--- a/deepface/models/face_detection/Dlib.py
+++ b/deepface/models/face_detection/Dlib.py
@@ -1,5 +1,5 @@
 # built-in dependencies
-from typing import List
+from typing import List, Union
 
 # 3rd party dependencies
 import numpy as np
@@ -47,9 +47,26 @@ class DlibClient(Detector):
         detector["sp"] = sp
         return detector
 
-    def detect_faces(self, img: np.ndarray) -> List[FacialAreaRegion]:
+    def detect_faces(self, img: Union[np.ndarray, List[np.ndarray]]) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
         """
         Detect and align face with dlib
+
+        Args:
+            img (Union[np.ndarray, List[np.ndarray]]): pre-loaded image as numpy array or a list of those
+
+        Returns:
+            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): A list or a list of lists of FacialAreaRegion objects
+        """
+        if isinstance(img, np.ndarray):
+            return self._detect_faces_in_single_image(img)
+        elif isinstance(img, list):
+            return [self._detect_faces_in_single_image(single_img) for single_img in img]
+        else:
+            raise ValueError("Input must be a numpy array or a list of numpy arrays.")
+
+    def _detect_faces_in_single_image(self, img: np.ndarray) -> List[FacialAreaRegion]:
+        """
+        Helper function to detect faces in a single image.
 
         Args:
             img (np.ndarray): pre-loaded image as numpy array

--- a/deepface/models/face_detection/Dlib.py
+++ b/deepface/models/face_detection/Dlib.py
@@ -62,10 +62,11 @@ class DlibClient(Detector):
             results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): 
             A list or a list of lists of FacialAreaRegion objects
         """
-        if not isinstance(img, list):
+        is_batched_input = isinstance(img, list)
+        if not is_batched_input:
             img = [img]
         results = [self._process_single_image(single_img) for single_img in img]
-        if len(results) == 1:
+        if not is_batched_input:
             return results[0]
         return results
 

--- a/deepface/models/face_detection/Dlib.py
+++ b/deepface/models/face_detection/Dlib.py
@@ -57,14 +57,14 @@ class DlibClient(Detector):
         Returns:
             results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): A list or a list of lists of FacialAreaRegion objects
         """
-        if isinstance(img, np.ndarray):
-            return self._detect_faces_in_single_image(img)
-        elif isinstance(img, list):
-            return [self._detect_faces_in_single_image(single_img) for single_img in img]
-        else:
-            raise ValueError("Input must be a numpy array or a list of numpy arrays.")
+        if not isinstance(img, list):
+            img = [img]
+        results = [self._process_single_image(single_img) for single_img in img]
+        if len(results) == 1:
+            return results[0]
+        return results
 
-    def _detect_faces_in_single_image(self, img: np.ndarray) -> List[FacialAreaRegion]:
+    def _process_single_image(self, img: np.ndarray) -> List[FacialAreaRegion]:
         """
         Helper function to detect faces in a single image.
 

--- a/deepface/models/face_detection/Dlib.py
+++ b/deepface/models/face_detection/Dlib.py
@@ -1,5 +1,5 @@
 # built-in dependencies
-from typing import List
+from typing import List, Union
 
 # 3rd party dependencies
 import numpy as np
@@ -46,6 +46,29 @@ class DlibClient(Detector):
         detector["face_detector"] = face_detector
         detector["sp"] = sp
         return detector
+
+    def detect_faces(
+        self,
+        img: Union[np.ndarray, List[np.ndarray]],
+    ) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
+        """
+        Detect and align face with dlib
+
+        Args:
+            img (Union[np.ndarray, List[np.ndarray]]): 
+            pre-loaded image as numpy array or a list of those
+
+        Returns:
+            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): 
+            A list or a list of lists of FacialAreaRegion objects
+        """
+        is_batched_input = isinstance(img, list)
+        if not is_batched_input:
+            img = [img]
+        results = [self._process_single_image(single_img) for single_img in img]
+        if not is_batched_input:
+            return results[0]
+        return results
 
     def _process_single_image(self, img: np.ndarray) -> List[FacialAreaRegion]:
         """

--- a/deepface/models/face_detection/FastMtCnn.py
+++ b/deepface/models/face_detection/FastMtCnn.py
@@ -32,10 +32,11 @@ class FastMtCnnClient(Detector):
             results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): 
             A list or a list of lists of FacialAreaRegion objects
         """
-        if not isinstance(img, list):
+        is_batched_input = isinstance(img, list)
+        if not is_batched_input:
             img = [img]
         results = [self._process_single_image(single_img) for single_img in img]
-        if len(results) == 1:
+        if not is_batched_input:
             return results[0]
         return results
 

--- a/deepface/models/face_detection/FastMtCnn.py
+++ b/deepface/models/face_detection/FastMtCnn.py
@@ -17,6 +17,29 @@ class FastMtCnnClient(Detector):
     def __init__(self):
         self.model = self.build_model()
 
+    def detect_faces(
+        self,
+        img: Union[np.ndarray, List[np.ndarray]],
+    ) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
+        """
+        Detect and align face with mtcnn
+
+        Args:
+            img (Union[np.ndarray, List[np.ndarray]]): 
+            pre-loaded image as numpy array or a list of those
+
+        Returns:
+            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): 
+            A list or a list of lists of FacialAreaRegion objects
+        """
+        is_batched_input = isinstance(img, list)
+        if not is_batched_input:
+            img = [img]
+        results = [self._process_single_image(single_img) for single_img in img]
+        if not is_batched_input:
+            return results[0]
+        return results
+
     def _process_single_image(self, img: np.ndarray) -> List[FacialAreaRegion]:
         """
         Helper function to detect faces in a single image.

--- a/deepface/models/face_detection/FastMtCnn.py
+++ b/deepface/models/face_detection/FastMtCnn.py
@@ -17,15 +17,20 @@ class FastMtCnnClient(Detector):
     def __init__(self):
         self.model = self.build_model()
 
-    def detect_faces(self, img: Union[np.ndarray, List[np.ndarray]]) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
+    def detect_faces(
+        self,
+        img: Union[np.ndarray, List[np.ndarray]],
+    ) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
         """
         Detect and align face with mtcnn
 
         Args:
-            img (Union[np.ndarray, List[np.ndarray]]): pre-loaded image as numpy array or a list of those
+            img (Union[np.ndarray, List[np.ndarray]]): 
+            pre-loaded image as numpy array or a list of those
 
         Returns:
-            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): A list or a list of lists of FacialAreaRegion objects
+            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): 
+            A list or a list of lists of FacialAreaRegion objects
         """
         if not isinstance(img, list):
             img = [img]

--- a/deepface/models/face_detection/FastMtCnn.py
+++ b/deepface/models/face_detection/FastMtCnn.py
@@ -17,9 +17,26 @@ class FastMtCnnClient(Detector):
     def __init__(self):
         self.model = self.build_model()
 
-    def detect_faces(self, img: np.ndarray) -> List[FacialAreaRegion]:
+    def detect_faces(self, img: Union[np.ndarray, List[np.ndarray]]) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
         """
         Detect and align face with mtcnn
+
+        Args:
+            img (Union[np.ndarray, List[np.ndarray]]): pre-loaded image as numpy array or a list of those
+
+        Returns:
+            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): A list or a list of lists of FacialAreaRegion objects
+        """
+        if isinstance(img, np.ndarray):
+            return self._process_single_image(img)
+        elif isinstance(img, list):
+            return [self._process_single_image(single_img) for single_img in img]
+        else:
+            raise ValueError("Input must be a numpy array or a list of numpy arrays.")
+
+    def _process_single_image(self, img: np.ndarray) -> List[FacialAreaRegion]:
+        """
+        Helper function to detect faces in a single image.
 
         Args:
             img (np.ndarray): pre-loaded image as numpy array

--- a/deepface/models/face_detection/FastMtCnn.py
+++ b/deepface/models/face_detection/FastMtCnn.py
@@ -27,12 +27,12 @@ class FastMtCnnClient(Detector):
         Returns:
             results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): A list or a list of lists of FacialAreaRegion objects
         """
-        if isinstance(img, np.ndarray):
-            return self._process_single_image(img)
-        elif isinstance(img, list):
-            return [self._process_single_image(single_img) for single_img in img]
-        else:
-            raise ValueError("Input must be a numpy array or a list of numpy arrays.")
+        if not isinstance(img, list):
+            img = [img]
+        results = [self._process_single_image(single_img) for single_img in img]
+        if len(results) == 1:
+            return results[0]
+        return results
 
     def _process_single_image(self, img: np.ndarray) -> List[FacialAreaRegion]:
         """

--- a/deepface/models/face_detection/FastMtCnn.py
+++ b/deepface/models/face_detection/FastMtCnn.py
@@ -17,29 +17,6 @@ class FastMtCnnClient(Detector):
     def __init__(self):
         self.model = self.build_model()
 
-    def detect_faces(
-        self,
-        img: Union[np.ndarray, List[np.ndarray]],
-    ) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
-        """
-        Detect and align face with mtcnn
-
-        Args:
-            img (Union[np.ndarray, List[np.ndarray]]): 
-            pre-loaded image as numpy array or a list of those
-
-        Returns:
-            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): 
-            A list or a list of lists of FacialAreaRegion objects
-        """
-        is_batched_input = isinstance(img, list)
-        if not is_batched_input:
-            img = [img]
-        results = [self._process_single_image(single_img) for single_img in img]
-        if not is_batched_input:
-            return results[0]
-        return results
-
     def _process_single_image(self, img: np.ndarray) -> List[FacialAreaRegion]:
         """
         Helper function to detect faces in a single image.

--- a/deepface/models/face_detection/MediaPipe.py
+++ b/deepface/models/face_detection/MediaPipe.py
@@ -1,6 +1,6 @@
 # built-in dependencies
 import os
-from typing import Any, List
+from typing import Any, List, Union
 
 # 3rd party dependencies
 import numpy as np
@@ -43,9 +43,26 @@ class MediaPipeClient(Detector):
         )
         return face_detection
 
-    def detect_faces(self, img: np.ndarray) -> List[FacialAreaRegion]:
+    def detect_faces(self, img: Union[np.ndarray, List[np.ndarray]]) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
         """
         Detect and align face with mediapipe
+
+        Args:
+            img (Union[np.ndarray, List[np.ndarray]]): pre-loaded image as numpy array or a list of those
+
+        Returns:
+            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): A list or a list of lists of FacialAreaRegion objects
+        """
+        if isinstance(img, np.ndarray):
+            return self._process_single_image(img)
+        elif isinstance(img, list):
+            return [self._process_single_image(single_img) for single_img in img]
+        else:
+            raise ValueError("Input must be a numpy array or a list of numpy arrays.")
+
+    def _process_single_image(self, img: np.ndarray) -> List[FacialAreaRegion]:
+        """
+        Helper function to detect faces in a single image.
 
         Args:
             img (np.ndarray): pre-loaded image as numpy array

--- a/deepface/models/face_detection/MediaPipe.py
+++ b/deepface/models/face_detection/MediaPipe.py
@@ -53,12 +53,12 @@ class MediaPipeClient(Detector):
         Returns:
             results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): A list or a list of lists of FacialAreaRegion objects
         """
-        if isinstance(img, np.ndarray):
-            return self._process_single_image(img)
-        elif isinstance(img, list):
-            return [self._process_single_image(single_img) for single_img in img]
-        else:
-            raise ValueError("Input must be a numpy array or a list of numpy arrays.")
+        if not isinstance(img, list):
+            img = [img]
+        results = [self._process_single_image(single_img) for single_img in img]
+        if len(results) == 1:
+            return results[0]
+        return results
 
     def _process_single_image(self, img: np.ndarray) -> List[FacialAreaRegion]:
         """

--- a/deepface/models/face_detection/MediaPipe.py
+++ b/deepface/models/face_detection/MediaPipe.py
@@ -1,6 +1,6 @@
 # built-in dependencies
 import os
-from typing import Any, List
+from typing import Any, List, Union
 
 # 3rd party dependencies
 import numpy as np
@@ -42,6 +42,29 @@ class MediaPipeClient(Detector):
             model_selection=model_selection
         )
         return face_detection
+
+    def detect_faces(
+        self,
+        img: Union[np.ndarray, List[np.ndarray]],
+    ) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
+        """
+        Detect and align face with mediapipe
+
+        Args:
+            img (Union[np.ndarray, List[np.ndarray]]): 
+            pre-loaded image as numpy array or a list of those
+
+        Returns:
+            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): 
+            A list or a list of lists of FacialAreaRegion objects
+        """
+        is_batched_input = isinstance(img, list)
+        if not is_batched_input:
+            img = [img]
+        results = [self._process_single_image(single_img) for single_img in img]
+        if not is_batched_input:
+            return results[0]
+        return results
 
     def _process_single_image(self, img: np.ndarray) -> List[FacialAreaRegion]:
         """

--- a/deepface/models/face_detection/MediaPipe.py
+++ b/deepface/models/face_detection/MediaPipe.py
@@ -58,10 +58,11 @@ class MediaPipeClient(Detector):
             results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): 
             A list or a list of lists of FacialAreaRegion objects
         """
-        if not isinstance(img, list):
+        is_batched_input = isinstance(img, list)
+        if not is_batched_input:
             img = [img]
         results = [self._process_single_image(single_img) for single_img in img]
-        if len(results) == 1:
+        if not is_batched_input:
             return results[0]
         return results
 

--- a/deepface/models/face_detection/MediaPipe.py
+++ b/deepface/models/face_detection/MediaPipe.py
@@ -1,6 +1,6 @@
 # built-in dependencies
 import os
-from typing import Any, List, Union
+from typing import Any, List
 
 # 3rd party dependencies
 import numpy as np
@@ -42,29 +42,6 @@ class MediaPipeClient(Detector):
             model_selection=model_selection
         )
         return face_detection
-
-    def detect_faces(
-        self,
-        img: Union[np.ndarray, List[np.ndarray]],
-    ) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
-        """
-        Detect and align face with mediapipe
-
-        Args:
-            img (Union[np.ndarray, List[np.ndarray]]): 
-            pre-loaded image as numpy array or a list of those
-
-        Returns:
-            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): 
-            A list or a list of lists of FacialAreaRegion objects
-        """
-        is_batched_input = isinstance(img, list)
-        if not is_batched_input:
-            img = [img]
-        results = [self._process_single_image(single_img) for single_img in img]
-        if not is_batched_input:
-            return results[0]
-        return results
 
     def _process_single_image(self, img: np.ndarray) -> List[FacialAreaRegion]:
         """

--- a/deepface/models/face_detection/MediaPipe.py
+++ b/deepface/models/face_detection/MediaPipe.py
@@ -43,15 +43,20 @@ class MediaPipeClient(Detector):
         )
         return face_detection
 
-    def detect_faces(self, img: Union[np.ndarray, List[np.ndarray]]) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
+    def detect_faces(
+        self,
+        img: Union[np.ndarray, List[np.ndarray]],
+    ) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
         """
         Detect and align face with mediapipe
 
         Args:
-            img (Union[np.ndarray, List[np.ndarray]]): pre-loaded image as numpy array or a list of those
+            img (Union[np.ndarray, List[np.ndarray]]): 
+            pre-loaded image as numpy array or a list of those
 
         Returns:
-            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): A list or a list of lists of FacialAreaRegion objects
+            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): 
+            A list or a list of lists of FacialAreaRegion objects
         """
         if not isinstance(img, list):
             img = [img]

--- a/deepface/models/face_detection/MtCnn.py
+++ b/deepface/models/face_detection/MtCnn.py
@@ -1,5 +1,5 @@
 # built-in dependencies
-from typing import List
+from typing import List, Union
 
 # 3rd party dependencies
 import numpy as np
@@ -17,44 +17,58 @@ class MtCnnClient(Detector):
     def __init__(self):
         self.model = MTCNN()
 
-    def detect_faces(self, img: np.ndarray) -> List[FacialAreaRegion]:
+    def detect_faces(
+        self, 
+        img: Union[np.ndarray, 
+        List[np.ndarray]]
+    ) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
         """
-        Detect and align face with mtcnn
+        Detect and align faces with mtcnn for a list of images
 
         Args:
-            img (np.ndarray): pre-loaded image as numpy array
+            imgs (Union[np.ndarray, List[np.ndarray]]): 
+                pre-loaded image as numpy array or a list of those
 
         Returns:
-            results (List[FacialAreaRegion]): A list of FacialAreaRegion objects
+            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): 
+                A list of FacialAreaRegion objects for a single image or a list of lists of FacialAreaRegion objects for each image
         """
+
+        if not isinstance(img, list):
+            img = [img]
 
         resp = []
 
         # mtcnn expects RGB but OpenCV read BGR
         # img_rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
-        img_rgb = img[:, :, ::-1]
+        img_rgb = [img[:, :, ::-1] for img in img]
         detections = self.model.detect_faces(img_rgb)
 
-        if detections is not None and len(detections) > 0:
+        for image_detections in detections:
+            image_resp = []
+            if image_detections is not None and len(image_detections) > 0:
+                for current_detection in image_detections:
+                    x, y, w, h = current_detection["box"]
+                    confidence = current_detection["confidence"]
+                    # mtcnn detector assigns left eye with respect to the observer
+                    # but we are setting it with respect to the person itself
+                    left_eye = current_detection["keypoints"]["right_eye"]
+                    right_eye = current_detection["keypoints"]["left_eye"]
 
-            for current_detection in detections:
-                x, y, w, h = current_detection["box"]
-                confidence = current_detection["confidence"]
-                # mtcnn detector assigns left eye with respect to the observer
-                # but we are setting it with respect to the person itself
-                left_eye = current_detection["keypoints"]["right_eye"]
-                right_eye = current_detection["keypoints"]["left_eye"]
+                    facial_area = FacialAreaRegion(
+                        x=x,
+                        y=y,
+                        w=w,
+                        h=h,
+                        left_eye=left_eye,
+                        right_eye=right_eye,
+                        confidence=confidence,
+                    )
 
-                facial_area = FacialAreaRegion(
-                    x=x,
-                    y=y,
-                    w=w,
-                    h=h,
-                    left_eye=left_eye,
-                    right_eye=right_eye,
-                    confidence=confidence,
-                )
+                    image_resp.append(facial_area)
 
-                resp.append(facial_area)
+            resp.append(image_resp)
 
+        if len(resp) == 1:
+            return resp[0]
         return resp

--- a/deepface/models/face_detection/MtCnn.py
+++ b/deepface/models/face_detection/MtCnn.py
@@ -18,9 +18,8 @@ class MtCnnClient(Detector):
         self.model = MTCNN()
 
     def detect_faces(
-        self, 
-        img: Union[np.ndarray, 
-        List[np.ndarray]]
+        self,
+        img: Union[np.ndarray, List[np.ndarray]]
     ) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
         """
         Detect and align faces with mtcnn for a list of images
@@ -31,7 +30,8 @@ class MtCnnClient(Detector):
 
         Returns:
             results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): 
-                A list of FacialAreaRegion objects for a single image or a list of lists of FacialAreaRegion objects for each image
+                A list of FacialAreaRegion objects for a single image 
+                or a list of lists of FacialAreaRegion objects for each image
         """
 
         if not isinstance(img, list):

--- a/deepface/models/face_detection/MtCnn.py
+++ b/deepface/models/face_detection/MtCnn.py
@@ -79,7 +79,7 @@ class MtCnnClient(Detector):
         if len(resp) == 1:
             return resp[0]
         return resp
-    
+
     def _supports_batch_detection(self) -> bool:
         import mtcnn
         try:

--- a/deepface/models/face_detection/MtCnn.py
+++ b/deepface/models/face_detection/MtCnn.py
@@ -82,32 +82,8 @@ class MtCnnClient(Detector):
         return resp
 
     def _supports_batch_detection(self) -> bool:
-        import mtcnn
-        import os
-        supports_batch_detection = os.getenv(
-            "ENABLE_MTCNN_BATCH_DETECTION", "false"
-        ).lower() == "true"
-        if not supports_batch_detection:
-            logger.warning(
-                "Batch detection is disabled for mtcnn by default "
-                "since the results are not consistent with single image detection. "
-                "You can force enable it by setting the environment variable "
-                "ENABLE_MTCNN_BATCH_DETECTION to true."
-            )
-            return False
-        try:
-            mtcnn_version = mtcnn.__version__
-            supports_batch_detection = mtcnn_version >= "1.0.0"
-        except AttributeError:
-            try:
-                import mtcnn.metadata
-                mtcnn_version = mtcnn.metadata.__version__
-            except AttributeError:
-                logger.warning("Failed to determine mtcnn version")
-                logger.warning("Fallback to single image detection")
-                return False
-        supports_batch_detection = mtcnn_version >= "1.0.0"
-        if not supports_batch_detection:
-            logger.warning("MtCnn version is less than 1.0.0, batch detection is not supported")
-            logger.warning("Fallback to single image detection")
-        return supports_batch_detection
+        logger.warning(
+            "Batch detection is disabled for mtcnn by default "
+            "since the results are not consistent with single image detection. "
+        )
+        return False

--- a/deepface/models/face_detection/MtCnn.py
+++ b/deepface/models/face_detection/MtCnn.py
@@ -82,8 +82,21 @@ class MtCnnClient(Detector):
 
     def _supports_batch_detection(self) -> bool:
         import mtcnn
+        import os
+        supports_batch_detection = os.getenv(
+            "ENABLE_MTCNN_BATCH_DETECTION", "false"
+        ).lower() == "true"
+        if not supports_batch_detection:
+            logger.warning(
+                "Batch detection is disabled for mtcnn by default "
+                "since the results are not consistent with single image detection. "
+                "You can force enable it by setting the environment variable "
+                "ENABLE_MTCNN_BATCH_DETECTION to true."
+            )
+            return False
         try:
             mtcnn_version = mtcnn.__version__
+            supports_batch_detection = mtcnn_version >= "1.0.0"
         except AttributeError:
             try:
                 import mtcnn.metadata

--- a/deepface/models/face_detection/MtCnn.py
+++ b/deepface/models/face_detection/MtCnn.py
@@ -38,7 +38,8 @@ class MtCnnClient(Detector):
                 or a list of lists of FacialAreaRegion objects for each image
         """
 
-        if not isinstance(img, list):
+        is_batched_input = isinstance(img, list)
+        if not is_batched_input:
             img = [img]
 
         resp = []
@@ -76,7 +77,7 @@ class MtCnnClient(Detector):
 
             resp.append(image_resp)
 
-        if len(resp) == 1:
+        if not is_batched_input:
             return resp[0]
         return resp
 

--- a/deepface/models/face_detection/OpenCv.py
+++ b/deepface/models/face_detection/OpenCv.py
@@ -33,17 +33,11 @@ class OpenCvClient(Detector):
         return detector
 
     def _supports_batch_detection(self) -> bool:
-        supports_batch_detection = os.getenv(
-            "ENABLE_OPENCV_BATCH_DETECTION", "false"
-        ).lower() == "true"
-        if not supports_batch_detection:
-            logger.warning(
-                "Batch detection is disabled for opencv by default "
-                "since the results are not consistent with single image detection. "
-                "You can force enable it by setting the environment variable "
-                "ENABLE_OPENCV_BATCH_DETECTION to true."
-            )
-        return supports_batch_detection
+        logger.warning(
+            "Batch detection is disabled for opencv by default "
+            "since the results are not consistent with single image detection. "
+        )
+        return False
 
     def detect_faces(
         self,

--- a/deepface/models/face_detection/OpenCv.py
+++ b/deepface/models/face_detection/OpenCv.py
@@ -29,35 +29,42 @@ class OpenCvClient(Detector):
         detector["eye_detector"] = self.__build_cascade("haarcascade_eye")
         return detector
 
-    def detect_faces(self, imgs: Union[np.ndarray, List[np.ndarray]]) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
+    def detect_faces(
+        self,
+        img: Union[np.ndarray, List[np.ndarray]]
+    ) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
         """
         Detect and align face with opencv
 
         Args:
-            imgs (Union[np.ndarray, List[np.ndarray]]): pre-loaded image as numpy array or a list of those
+            img (Union[np.ndarray, List[np.ndarray]]):
+            Pre-loaded image as numpy array or a list of those
 
         Returns:
-            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): A list or a list of lists of FacialAreaRegion objects
+            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): 
+            A list or a list of lists of FacialAreaRegion objects
         """
-        if isinstance(imgs, np.ndarray):
-            imgs = [imgs]
+        if isinstance(img, np.ndarray):
+            imgs = [img]
+        else:
+            imgs = img
 
         batch_results = []
 
-        for img in imgs:
+        for single_img in imgs:
             resp = []
             detected_face = None
             faces = []
             try:
                 faces, _, scores = self.model["face_detector"].detectMultiScale3(
-                    img, 1.1, 10, outputRejectLevels=True
+                    single_img, 1.1, 10, outputRejectLevels=True
                 )
             except:
                 pass
 
             if len(faces) > 0:
                 for (x, y, w, h), confidence in zip(faces, scores):
-                    detected_face = img[int(y):int(y + h), int(x):int(x + w)]
+                    detected_face = single_img[int(y):int(y + h), int(x):int(x + w)]
                     left_eye, right_eye = self.find_eyes(img=detected_face)
 
                     if left_eye is not None:

--- a/deepface/models/face_detection/OpenCv.py
+++ b/deepface/models/face_detection/OpenCv.py
@@ -1,6 +1,6 @@
 # built-in dependencies
 import os
-from typing import Any, List, Union
+from typing import Any, List
 import logging
 
 # 3rd party dependencies
@@ -45,65 +45,48 @@ class OpenCvClient(Detector):
             )
         return supports_batch_detection
 
-    def detect_faces(
-        self,
-        img: Union[np.ndarray, List[np.ndarray]]
-    ) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
+    def _process_single_image(self, img: np.ndarray) -> List[FacialAreaRegion]:
         """
-        Detect and align face with opencv
+        Helper function to detect faces in a single image.
 
         Args:
-            img (Union[np.ndarray, List[np.ndarray]]):
-            Pre-loaded image as numpy array or a list of those
+            img (np.ndarray): pre-loaded image as numpy array
 
         Returns:
-            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): 
-            A list or a list of lists of FacialAreaRegion objects
+            results (List[FacialAreaRegion]): A list of FacialAreaRegion objects
         """
-        if isinstance(img, np.ndarray):
-            imgs = [img]
-        elif self.supports_batch_detection:
-            imgs = img
-        else:
-            return [self.detect_faces(single_img) for single_img in img]
+        resp = []
+        detected_face = None
+        faces = []
+        try:
+            faces, _, scores = self.model["face_detector"].detectMultiScale3(
+                img, 1.1, 10, outputRejectLevels=True
+            )
+        except:
+            pass
 
-        batch_results = []
+        if len(faces) > 0:
+            for (x, y, w, h), confidence in zip(faces, scores):
+                detected_face = img[int(y):int(y + h), int(x):int(x + w)]
+                left_eye, right_eye = self.find_eyes(img=detected_face)
 
-        for single_img in imgs:
-            resp = []
-            detected_face = None
-            faces = []
-            try:
-                faces, _, scores = self.model["face_detector"].detectMultiScale3(
-                    single_img, 1.1, 10, outputRejectLevels=True
+                if left_eye is not None:
+                    left_eye = (int(x + left_eye[0]), int(y + left_eye[1]))
+                if right_eye is not None:
+                    right_eye = (int(x + right_eye[0]), int(y + right_eye[1]))
+
+                facial_area = FacialAreaRegion(
+                    x=x,
+                    y=y,
+                    w=w,
+                    h=h,
+                    left_eye=left_eye,
+                    right_eye=right_eye,
+                    confidence=(100 - confidence) / 100,
                 )
-            except:
-                pass
+                resp.append(facial_area)
 
-            if len(faces) > 0:
-                for (x, y, w, h), confidence in zip(faces, scores):
-                    detected_face = single_img[int(y):int(y + h), int(x):int(x + w)]
-                    left_eye, right_eye = self.find_eyes(img=detected_face)
-
-                    if left_eye is not None:
-                        left_eye = (int(x + left_eye[0]), int(y + left_eye[1]))
-                    if right_eye is not None:
-                        right_eye = (int(x + right_eye[0]), int(y + right_eye[1]))
-
-                    facial_area = FacialAreaRegion(
-                        x=x,
-                        y=y,
-                        w=w,
-                        h=h,
-                        left_eye=left_eye,
-                        right_eye=right_eye,
-                        confidence=(100 - confidence) / 100,
-                    )
-                    resp.append(facial_area)
-
-            batch_results.append(resp)
-
-        return batch_results if len(batch_results) > 1 else batch_results[0]
+        return resp
 
     def find_eyes(self, img: np.ndarray) -> tuple:
         """

--- a/deepface/models/face_detection/OpenCv.py
+++ b/deepface/models/face_detection/OpenCv.py
@@ -31,7 +31,7 @@ class OpenCvClient(Detector):
         detector["face_detector"] = self.__build_cascade("haarcascade")
         detector["eye_detector"] = self.__build_cascade("haarcascade_eye")
         return detector
-    
+
     def _supports_batch_detection(self) -> bool:
         supports_batch_detection = os.getenv(
             "ENABLE_OPENCV_BATCH_DETECTION", "false"

--- a/deepface/models/face_detection/RetinaFace.py
+++ b/deepface/models/face_detection/RetinaFace.py
@@ -28,7 +28,8 @@ class RetinaFaceClient(Detector):
             results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): 
             A list or a list of lists of FacialAreaRegion objects
         """
-        if isinstance(img, np.ndarray):
+        is_batched_input = isinstance(img, list)
+        if not is_batched_input:
             imgs = [img]
         else:
             imgs = img
@@ -81,4 +82,6 @@ class RetinaFaceClient(Detector):
 
             batch_results.append(resp)
 
-        return batch_results if len(batch_results) > 1 else batch_results[0]
+        if not is_batched_input:
+            return batch_results[0]
+        return batch_results

--- a/deepface/models/face_detection/RetinaFace.py
+++ b/deepface/models/face_detection/RetinaFace.py
@@ -13,15 +13,20 @@ class RetinaFaceClient(Detector):
     def __init__(self):
         self.model = rf.build_model()
 
-    def detect_faces(self, img: Union[np.ndarray, List[np.ndarray]]) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
+    def detect_faces(
+        self,
+        img: Union[np.ndarray, List[np.ndarray]]
+    ) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
         """
-        Detect and align faces with retinaface in an image or a list of images
+        Detect and align faces with retinaface in a batch of images
 
         Args:
-            img (Union[np.ndarray, List[np.ndarray]]): pre-loaded image as numpy array or a list of those
+            img (Union[np.ndarray, List[np.ndarray]]): 
+            Pre-loaded image as numpy array or a list of those
 
         Returns:
-            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): A list or a list of lists of FacialAreaRegion objects
+            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): 
+            A list or a list of lists of FacialAreaRegion objects
         """
         if isinstance(img, np.ndarray):
             imgs = [img]
@@ -30,9 +35,9 @@ class RetinaFaceClient(Detector):
 
         batch_results = []
 
-        for img in imgs:
+        for single_img in imgs:
             resp = []
-            obj = rf.detect_faces(img, model=self.model, threshold=0.9)
+            obj = rf.detect_faces(single_img, model=self.model, threshold=0.9)
 
             if isinstance(obj, dict):
                 for face_idx in obj.keys():

--- a/deepface/models/face_detection/Ssd.py
+++ b/deepface/models/face_detection/Ssd.py
@@ -1,5 +1,5 @@
 # built-in dependencies
-from typing import List
+from typing import List, Union
 from enum import IntEnum
 
 # 3rd party dependencies
@@ -54,25 +54,48 @@ class SsdClient(Detector):
 
         return {"face_detector": face_detector, "opencv_module": OpenCv.OpenCvClient()}
 
-    def _process_single_image(self, img: np.ndarray) -> List[FacialAreaRegion]:
+    def detect_faces(
+        self,
+        img: Union[np.ndarray, List[np.ndarray]]
+    ) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
+        """
+        Detect and align faces with ssd in a batch of images
+
+        Args:
+            img (Union[np.ndarray, List[np.ndarray]]): 
+            Pre-loaded image as numpy array or a list of those
+
+        Returns:
+            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): 
+            A list or a list of lists of FacialAreaRegion objects
+        """
+        is_batched_input = isinstance(img, list)
+        if not is_batched_input:
+            img = [img]
+        results = [self._process_single_image(single_img) for single_img in img]
+        if not is_batched_input:
+            return results[0]
+        return results
+
+    def _process_single_image(self, single_img: np.ndarray) -> List[FacialAreaRegion]:
         """
         Helper function to detect faces in a single image.
 
         Args:
-            img (np.ndarray): Pre-loaded image as numpy array
+            single_img (np.ndarray): Pre-loaded image as numpy array
 
         Returns:
             results (List[FacialAreaRegion]): A list of FacialAreaRegion objects
         """
         # Because cv2.dnn.blobFromImage expects CV_8U (8-bit unsigned integer) values
-        if img.dtype != np.uint8:
-            img = img.astype(np.uint8)
+        if single_img.dtype != np.uint8:
+            single_img = single_img.astype(np.uint8)
 
         opencv_module: OpenCv.OpenCvClient = self.model["opencv_module"]
 
         target_size = (300, 300)
-        original_size = img.shape
-        current_img = cv2.resize(img, target_size)
+        original_size = single_img.shape
+        current_img = cv2.resize(single_img, target_size)
 
         aspect_ratio_x = original_size[1] / target_size[1]
         aspect_ratio_y = original_size[0] / target_size[0]
@@ -109,7 +132,7 @@ class SsdClient(Detector):
         for face in faces:
             confidence = float(face[ssd_labels.confidence])
             x, y, w, h = map(int, face[margins])
-            detected_face = img[y : y + h, x : x + w]
+            detected_face = single_img[y : y + h, x : x + w]
 
             left_eye, right_eye = opencv_module.find_eyes(detected_face)
 

--- a/deepface/models/face_detection/Ssd.py
+++ b/deepface/models/face_detection/Ssd.py
@@ -1,5 +1,5 @@
 # built-in dependencies
-from typing import List
+from typing import List, Union
 from enum import IntEnum
 
 # 3rd party dependencies
@@ -54,83 +54,96 @@ class SsdClient(Detector):
 
         return {"face_detector": face_detector, "opencv_module": OpenCv.OpenCvClient()}
 
-    def detect_faces(self, img: np.ndarray) -> List[FacialAreaRegion]:
+    def detect_faces(
+        self,
+        img: Union[np.ndarray, List[np.ndarray]]
+    ) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
         """
-        Detect and align face with ssd
+        Detect and align faces with ssd in a batch of images
 
         Args:
-            img (np.ndarray): pre-loaded image as numpy array
+            img (Union[np.ndarray, List[np.ndarray]]): 
+            Pre-loaded image as numpy array or a list of those
 
         Returns:
-            results (List[FacialAreaRegion]): A list of FacialAreaRegion objects
+            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): 
+            A list or a list of lists of FacialAreaRegion objects
         """
+        if isinstance(img, np.ndarray):
+            imgs = [img]
+        else:
+            imgs = img
 
-        # Because cv2.dnn.blobFromImage expects CV_8U (8-bit unsigned integer) values
-        if img.dtype != np.uint8:
-            img = img.astype(np.uint8)
+        batch_results = []
 
-        opencv_module: OpenCv.OpenCvClient = self.model["opencv_module"]
+        for single_img in imgs:
+            # Because cv2.dnn.blobFromImage expects CV_8U (8-bit unsigned integer) values
+            if single_img.dtype != np.uint8:
+                single_img = single_img.astype(np.uint8)
 
-        target_size = (300, 300)
+            opencv_module: OpenCv.OpenCvClient = self.model["opencv_module"]
 
-        original_size = img.shape
+            target_size = (300, 300)
+            original_size = single_img.shape
+            current_img = cv2.resize(single_img, target_size)
 
-        current_img = cv2.resize(img, target_size)
+            aspect_ratio_x = original_size[1] / target_size[1]
+            aspect_ratio_y = original_size[0] / target_size[0]
 
-        aspect_ratio_x = original_size[1] / target_size[1]
-        aspect_ratio_y = original_size[0] / target_size[0]
+            imageBlob = cv2.dnn.blobFromImage(image=current_img)
 
-        imageBlob = cv2.dnn.blobFromImage(image=current_img)
+            face_detector = self.model["face_detector"]
+            face_detector.setInput(imageBlob)
+            detections = face_detector.forward()
 
-        face_detector = self.model["face_detector"]
-        face_detector.setInput(imageBlob)
-        detections = face_detector.forward()
+            class ssd_labels(IntEnum):
+                img_id = 0
+                is_face = 1
+                confidence = 2
+                left = 3
+                top = 4
+                right = 5
+                bottom = 6
 
-        class ssd_labels(IntEnum):
-            img_id = 0
-            is_face = 1
-            confidence = 2
-            left = 3
-            top = 4
-            right = 5
-            bottom = 6
-
-        faces = detections[0][0]
-        faces = faces[
-            (faces[:, ssd_labels.is_face] == 1) & (faces[:, ssd_labels.confidence] >= 0.90)
-        ]
-        margins = [ssd_labels.left, ssd_labels.top, ssd_labels.right, ssd_labels.bottom]
-        faces[:, margins] = np.int32(faces[:, margins] * 300)
-        faces[:, margins] = np.int32(
-            faces[:, margins] * [aspect_ratio_x, aspect_ratio_y, aspect_ratio_x, aspect_ratio_y]
-        )
-        faces[:, [ssd_labels.right, ssd_labels.bottom]] -= faces[
-            :, [ssd_labels.left, ssd_labels.top]
-        ]
-
-        resp = []
-        for face in faces:
-            confidence = float(face[ssd_labels.confidence])
-            x, y, w, h = map(int, face[margins])
-            detected_face = img[y : y + h, x : x + w]
-
-            left_eye, right_eye = opencv_module.find_eyes(detected_face)
-
-            # eyes found in the detected face instead image itself
-            # detected face's coordinates should be added
-            if left_eye is not None:
-                left_eye = x + int(left_eye[0]), y + int(left_eye[1])
-            if right_eye is not None:
-                right_eye = x + int(right_eye[0]), y + int(right_eye[1])
-
-            facial_area = FacialAreaRegion(
-                x=x,
-                y=y,
-                w=w,
-                h=h,
-                left_eye=left_eye,
-                right_eye=right_eye,
-                confidence=confidence,
+            faces = detections[0][0]
+            faces = faces[
+                (faces[:, ssd_labels.is_face] == 1) & (faces[:, ssd_labels.confidence] >= 0.90)
+            ]
+            margins = [ssd_labels.left, ssd_labels.top, ssd_labels.right, ssd_labels.bottom]
+            faces[:, margins] = np.int32(faces[:, margins] * 300)
+            faces[:, margins] = np.int32(
+                faces[:, margins] * [aspect_ratio_x, aspect_ratio_y, aspect_ratio_x, aspect_ratio_y]
             )
-            resp.append(facial_area)
-        return resp
+            faces[:, [ssd_labels.right, ssd_labels.bottom]] -= faces[
+                :, [ssd_labels.left, ssd_labels.top]
+            ]
+
+            resp = []
+            for face in faces:
+                confidence = float(face[ssd_labels.confidence])
+                x, y, w, h = map(int, face[margins])
+                detected_face = single_img[y : y + h, x : x + w]
+
+                left_eye, right_eye = opencv_module.find_eyes(detected_face)
+
+                # eyes found in the detected face instead image itself
+                # detected face's coordinates should be added
+                if left_eye is not None:
+                    left_eye = x + int(left_eye[0]), y + int(left_eye[1])
+                if right_eye is not None:
+                    right_eye = x + int(right_eye[0]), y + int(right_eye[1])
+
+                facial_area = FacialAreaRegion(
+                    x=x,
+                    y=y,
+                    w=w,
+                    h=h,
+                    left_eye=left_eye,
+                    right_eye=right_eye,
+                    confidence=confidence,
+                )
+                resp.append(facial_area)
+
+            batch_results.append(resp)
+
+        return batch_results if len(batch_results) > 1 else batch_results[0]

--- a/deepface/models/face_detection/Ssd.py
+++ b/deepface/models/face_detection/Ssd.py
@@ -69,81 +69,89 @@ class SsdClient(Detector):
             results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): 
             A list or a list of lists of FacialAreaRegion objects
         """
-        if isinstance(img, np.ndarray):
-            imgs = [img]
-        else:
-            imgs = img
+        is_batched_input = isinstance(img, list)
+        if not is_batched_input:
+            img = [img]
+        results = [self._process_single_image(single_img) for single_img in img]
+        if not is_batched_input:
+            return results[0]
+        return results
 
-        batch_results = []
+    def _process_single_image(self, single_img: np.ndarray) -> List[FacialAreaRegion]:
+        """
+        Helper function to detect faces in a single image.
 
-        for single_img in imgs:
-            # Because cv2.dnn.blobFromImage expects CV_8U (8-bit unsigned integer) values
-            if single_img.dtype != np.uint8:
-                single_img = single_img.astype(np.uint8)
+        Args:
+            single_img (np.ndarray): Pre-loaded image as numpy array
 
-            opencv_module: OpenCv.OpenCvClient = self.model["opencv_module"]
+        Returns:
+            results (List[FacialAreaRegion]): A list of FacialAreaRegion objects
+        """
+        # Because cv2.dnn.blobFromImage expects CV_8U (8-bit unsigned integer) values
+        if single_img.dtype != np.uint8:
+            single_img = single_img.astype(np.uint8)
 
-            target_size = (300, 300)
-            original_size = single_img.shape
-            current_img = cv2.resize(single_img, target_size)
+        opencv_module: OpenCv.OpenCvClient = self.model["opencv_module"]
 
-            aspect_ratio_x = original_size[1] / target_size[1]
-            aspect_ratio_y = original_size[0] / target_size[0]
+        target_size = (300, 300)
+        original_size = single_img.shape
+        current_img = cv2.resize(single_img, target_size)
 
-            imageBlob = cv2.dnn.blobFromImage(image=current_img)
+        aspect_ratio_x = original_size[1] / target_size[1]
+        aspect_ratio_y = original_size[0] / target_size[0]
 
-            face_detector = self.model["face_detector"]
-            face_detector.setInput(imageBlob)
-            detections = face_detector.forward()
+        imageBlob = cv2.dnn.blobFromImage(image=current_img)
 
-            class ssd_labels(IntEnum):
-                img_id = 0
-                is_face = 1
-                confidence = 2
-                left = 3
-                top = 4
-                right = 5
-                bottom = 6
+        face_detector = self.model["face_detector"]
+        face_detector.setInput(imageBlob)
+        detections = face_detector.forward()
 
-            faces = detections[0][0]
-            faces = faces[
-                (faces[:, ssd_labels.is_face] == 1) & (faces[:, ssd_labels.confidence] >= 0.90)
-            ]
-            margins = [ssd_labels.left, ssd_labels.top, ssd_labels.right, ssd_labels.bottom]
-            faces[:, margins] = np.int32(faces[:, margins] * 300)
-            faces[:, margins] = np.int32(
-                faces[:, margins] * [aspect_ratio_x, aspect_ratio_y, aspect_ratio_x, aspect_ratio_y]
+        class ssd_labels(IntEnum):
+            img_id = 0
+            is_face = 1
+            confidence = 2
+            left = 3
+            top = 4
+            right = 5
+            bottom = 6
+
+        faces = detections[0][0]
+        faces = faces[
+            (faces[:, ssd_labels.is_face] == 1) & (faces[:, ssd_labels.confidence] >= 0.90)
+        ]
+        margins = [ssd_labels.left, ssd_labels.top, ssd_labels.right, ssd_labels.bottom]
+        faces[:, margins] = np.int32(faces[:, margins] * 300)
+        faces[:, margins] = np.int32(
+            faces[:, margins] * [aspect_ratio_x, aspect_ratio_y, aspect_ratio_x, aspect_ratio_y]
+        )
+        faces[:, [ssd_labels.right, ssd_labels.bottom]] -= faces[
+            :, [ssd_labels.left, ssd_labels.top]
+        ]
+
+        resp = []
+        for face in faces:
+            confidence = float(face[ssd_labels.confidence])
+            x, y, w, h = map(int, face[margins])
+            detected_face = single_img[y : y + h, x : x + w]
+
+            left_eye, right_eye = opencv_module.find_eyes(detected_face)
+
+            # eyes found in the detected face instead image itself
+            # detected face's coordinates should be added
+            if left_eye is not None:
+                left_eye = x + int(left_eye[0]), y + int(left_eye[1])
+            if right_eye is not None:
+                right_eye = x + int(right_eye[0]), y + int(right_eye[1])
+
+            facial_area = FacialAreaRegion(
+                x=x,
+                y=y,
+                w=w,
+                h=h,
+                left_eye=left_eye,
+                right_eye=right_eye,
+                confidence=confidence,
             )
-            faces[:, [ssd_labels.right, ssd_labels.bottom]] -= faces[
-                :, [ssd_labels.left, ssd_labels.top]
-            ]
+            resp.append(facial_area)
 
-            resp = []
-            for face in faces:
-                confidence = float(face[ssd_labels.confidence])
-                x, y, w, h = map(int, face[margins])
-                detected_face = single_img[y : y + h, x : x + w]
-
-                left_eye, right_eye = opencv_module.find_eyes(detected_face)
-
-                # eyes found in the detected face instead image itself
-                # detected face's coordinates should be added
-                if left_eye is not None:
-                    left_eye = x + int(left_eye[0]), y + int(left_eye[1])
-                if right_eye is not None:
-                    right_eye = x + int(right_eye[0]), y + int(right_eye[1])
-
-                facial_area = FacialAreaRegion(
-                    x=x,
-                    y=y,
-                    w=w,
-                    h=h,
-                    left_eye=left_eye,
-                    right_eye=right_eye,
-                    confidence=confidence,
-                )
-                resp.append(facial_area)
-
-            batch_results.append(resp)
-
-        return batch_results if len(batch_results) > 1 else batch_results[0]
+        return resp

--- a/deepface/models/face_detection/Yolo.py
+++ b/deepface/models/face_detection/Yolo.py
@@ -1,6 +1,6 @@
 # built-in dependencies
 import os
-from typing import List, Any, Union, Tuple
+from typing import List, Any, Union
 from enum import Enum
 
 # 3rd party dependencies
@@ -62,25 +62,30 @@ class YoloDetectorClient(Detector):
         # Return face_detector
         return YOLO(weight_file)
 
-    def detect_faces(self, imgs: Union[np.ndarray, List[np.ndarray]]) -> Union[List[List[FacialAreaRegion]], List[FacialAreaRegion]]:
+    def detect_faces(
+        self,
+        img: Union[np.ndarray, List[np.ndarray]]
+    ) -> Union[List[List[FacialAreaRegion]], List[FacialAreaRegion]]:
         """
-        Detect and align faces in an image or a list of images with yolo
+        Detect and align faces in a batch of images with yolo
 
         Args:
-            imgs (Union[np.ndarray, List[np.ndarray]]): pre-loaded image as numpy array or a list of those
+            img (Union[np.ndarray, List[np.ndarray]]): 
+            Pre-loaded image as numpy array or a list of those
 
         Returns:
             results (Union[List[List[FacialAreaRegion]], List[FacialAreaRegion]]): 
-                A list of lists of FacialAreaRegion objects for each image or a list of FacialAreaRegion objects
+            A list of lists of FacialAreaRegion objects 
+            for each image or a list of FacialAreaRegion objects
         """
-        if not isinstance(imgs, list):
-            imgs = [imgs]
+        if not isinstance(img, list):
+            img = [img]
 
         all_results = []
 
         # Detect faces for all images
         results_list = self.model.predict(
-            imgs,
+            img,
             verbose=False,
             show=False,
             conf=float(os.getenv("YOLO_MIN_DETECTION_CONFIDENCE", "0.25")),
@@ -113,9 +118,16 @@ class YoloDetectorClient(Detector):
 
                     # eyes are list of float, need to cast them tuple of int
                     # Ensure eyes are tuples of exactly two integers or None
-                    left_eye = tuple(map(int, left_eye[:2])) if left_eye and len(left_eye) == 2 else None
-                    right_eye = tuple(map(int, right_eye[:2])) if right_eye and len(right_eye) == 2 else None
-
+                    left_eye = (
+                        tuple(map(int, left_eye[:2]))
+                        if left_eye and len(left_eye) == 2
+                        else None
+                    )
+                    right_eye = (
+                        tuple(map(int, right_eye[:2]))
+                        if right_eye and len(right_eye) == 2
+                        else None
+                    )
                 x, y, w, h = int(x - w / 2), int(y - h / 2), int(w), int(h)
                 facial_area = FacialAreaRegion(
                     x=x,

--- a/deepface/models/face_detection/Yolo.py
+++ b/deepface/models/face_detection/Yolo.py
@@ -78,7 +78,8 @@ class YoloDetectorClient(Detector):
             A list of lists of FacialAreaRegion objects 
             for each image or a list of FacialAreaRegion objects
         """
-        if not isinstance(img, list):
+        is_batched_input = isinstance(img, list)
+        if not is_batched_input:
             img = [img]
 
         all_results = []
@@ -142,7 +143,7 @@ class YoloDetectorClient(Detector):
 
             all_results.append(resp)
 
-        if len(all_results) == 1:
+        if not is_batched_input:
             return all_results[0]
         return all_results
 

--- a/deepface/models/face_detection/Yolo.py
+++ b/deepface/models/face_detection/Yolo.py
@@ -1,6 +1,6 @@
 # built-in dependencies
 import os
-from typing import List, Any
+from typing import List, Any, Union, Tuple
 from enum import Enum
 
 # 3rd party dependencies
@@ -62,64 +62,77 @@ class YoloDetectorClient(Detector):
         # Return face_detector
         return YOLO(weight_file)
 
-    def detect_faces(self, img: np.ndarray) -> List[FacialAreaRegion]:
+    def detect_faces(self, imgs: Union[np.ndarray, List[np.ndarray]]) -> Union[List[List[FacialAreaRegion]], List[FacialAreaRegion]]:
         """
-        Detect and align face with yolo
+        Detect and align faces in an image or a list of images with yolo
 
         Args:
-            img (np.ndarray): pre-loaded image as numpy array
+            imgs (Union[np.ndarray, List[np.ndarray]]): pre-loaded image as numpy array or a list of those
 
         Returns:
-            results (List[FacialAreaRegion]): A list of FacialAreaRegion objects
+            results (Union[List[List[FacialAreaRegion]], List[FacialAreaRegion]]): 
+                A list of lists of FacialAreaRegion objects for each image or a list of FacialAreaRegion objects
         """
-        resp = []
+        if not isinstance(imgs, list):
+            imgs = [imgs]
 
-        # Detect faces
-        results = self.model.predict(
-            img,
+        all_results = []
+
+        # Detect faces for all images
+        results_list = self.model.predict(
+            imgs,
             verbose=False,
             show=False,
             conf=float(os.getenv("YOLO_MIN_DETECTION_CONFIDENCE", "0.25")),
-        )[0]
+        )
 
-        # For each face, extract the bounding box, the landmarks and confidence
-        for result in results:
+        # Iterate over each image's results
+        for results in results_list:
+            resp = []
 
-            if result.boxes is None:
-                continue
+            # For each face, extract the bounding box, the landmarks and confidence
+            for result in results:
 
-            # Extract the bounding box and the confidence
-            x, y, w, h = result.boxes.xywh.tolist()[0]
-            confidence = result.boxes.conf.tolist()[0]
+                if result.boxes is None:
+                    continue
 
-            right_eye = None
-            left_eye = None
+                # Extract the bounding box and the confidence
+                x, y, w, h = result.boxes.xywh.tolist()[0]
+                confidence = result.boxes.conf.tolist()[0]
 
-            # yolo-facev8 is detecting eyes through keypoints,
-            # while for v11 keypoints are always None
-            if result.keypoints is not None:
-                # right_eye_conf = result.keypoints.conf[0][0]
-                # left_eye_conf = result.keypoints.conf[0][1]
-                right_eye = result.keypoints.xy[0][0].tolist()
-                left_eye = result.keypoints.xy[0][1].tolist()
+                right_eye = None
+                left_eye = None
 
-                # eyes are list of float, need to cast them tuple of int
-                left_eye = tuple(int(i) for i in left_eye)
-                right_eye = tuple(int(i) for i in right_eye)
+                # yolo-facev8 is detecting eyes through keypoints,
+                # while for v11 keypoints are always None
+                if result.keypoints is not None:
+                    # right_eye_conf = result.keypoints.conf[0][0]
+                    # left_eye_conf = result.keypoints.conf[0][1]
+                    right_eye = result.keypoints.xy[0][0].tolist()
+                    left_eye = result.keypoints.xy[0][1].tolist()
 
-            x, y, w, h = int(x - w / 2), int(y - h / 2), int(w), int(h)
-            facial_area = FacialAreaRegion(
-                x=x,
-                y=y,
-                w=w,
-                h=h,
-                left_eye=left_eye,
-                right_eye=right_eye,
-                confidence=confidence,
-            )
-            resp.append(facial_area)
+                    # eyes are list of float, need to cast them tuple of int
+                    # Ensure eyes are tuples of exactly two integers or None
+                    left_eye = tuple(map(int, left_eye[:2])) if left_eye and len(left_eye) == 2 else None
+                    right_eye = tuple(map(int, right_eye[:2])) if right_eye and len(right_eye) == 2 else None
 
-        return resp
+                x, y, w, h = int(x - w / 2), int(y - h / 2), int(w), int(h)
+                facial_area = FacialAreaRegion(
+                    x=x,
+                    y=y,
+                    w=w,
+                    h=h,
+                    left_eye=left_eye,
+                    right_eye=right_eye,
+                    confidence=confidence,
+                )
+                resp.append(facial_area)
+
+            all_results.append(resp)
+
+        if len(all_results) == 1:
+            return all_results[0]
+        return all_results
 
 
 class YoloDetectorClientV8n(YoloDetectorClient):

--- a/deepface/models/face_detection/Yolo.py
+++ b/deepface/models/face_detection/Yolo.py
@@ -78,8 +78,7 @@ class YoloDetectorClient(Detector):
             A list of lists of FacialAreaRegion objects 
             for each image or a list of FacialAreaRegion objects
         """
-        is_batched_input = isinstance(img, list)
-        if not is_batched_input:
+        if not isinstance(img, list):
             img = [img]
 
         all_results = []
@@ -143,7 +142,7 @@ class YoloDetectorClient(Detector):
 
             all_results.append(resp)
 
-        if not is_batched_input:
+        if len(all_results) == 1:
             return all_results[0]
         return all_results
 

--- a/deepface/models/face_detection/YuNet.py
+++ b/deepface/models/face_detection/YuNet.py
@@ -1,6 +1,6 @@
 # built-in dependencies
 import os
-from typing import Any, List, Union
+from typing import Any, List
 
 # 3rd party dependencies
 import cv2
@@ -56,24 +56,6 @@ class YuNetClient(Detector):
                 + "You can install it as pip install opencv-contrib-python."
             ) from err
         return face_detector
-
-    def detect_faces(self, img: Union[np.ndarray, List[np.ndarray]]) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
-        """
-        Detect and align face with yunet
-
-        Args:
-            img (Union[np.ndarray, List[np.ndarray]]): pre-loaded image as numpy array or a list of those
-
-        Returns:
-            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): A list or a list of lists of FacialAreaRegion objects
-        """
-        is_batched_input = isinstance(img, list)
-        if not is_batched_input:
-            img = [img]
-        results = [self._process_single_image(single_img) for single_img in img]
-        if not is_batched_input:
-            return results[0]
-        return results
 
     def _process_single_image(self, img: np.ndarray) -> List[FacialAreaRegion]:
         """

--- a/deepface/models/face_detection/YuNet.py
+++ b/deepface/models/face_detection/YuNet.py
@@ -1,6 +1,6 @@
 # built-in dependencies
 import os
-from typing import Any, List
+from typing import Any, List, Union
 
 # 3rd party dependencies
 import cv2
@@ -56,6 +56,24 @@ class YuNetClient(Detector):
                 + "You can install it as pip install opencv-contrib-python."
             ) from err
         return face_detector
+
+    def detect_faces(self, img: Union[np.ndarray, List[np.ndarray]]) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
+        """
+        Detect and align face with yunet
+
+        Args:
+            img (Union[np.ndarray, List[np.ndarray]]): pre-loaded image as numpy array or a list of those
+
+        Returns:
+            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): A list or a list of lists of FacialAreaRegion objects
+        """
+        is_batched_input = isinstance(img, list)
+        if not is_batched_input:
+            img = [img]
+        results = [self._process_single_image(single_img) for single_img in img]
+        if not is_batched_input:
+            return results[0]
+        return results
 
     def _process_single_image(self, img: np.ndarray) -> List[FacialAreaRegion]:
         """

--- a/deepface/models/face_detection/YuNet.py
+++ b/deepface/models/face_detection/YuNet.py
@@ -67,12 +67,12 @@ class YuNetClient(Detector):
         Returns:
             results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): A list or a list of lists of FacialAreaRegion objects
         """
-        if isinstance(img, np.ndarray):
-            return self._process_single_image(img)
-        elif isinstance(img, list):
-            return [self._process_single_image(single_img) for single_img in img]
-        else:
-            raise ValueError("Input must be a numpy array or a list of numpy arrays.")
+        if not isinstance(img, list):
+            img = [img]
+        results = [self._process_single_image(single_img) for single_img in img]
+        if len(results) == 1:
+            return results[0]
+        return results
 
     def _process_single_image(self, img: np.ndarray) -> List[FacialAreaRegion]:
         """

--- a/deepface/models/face_detection/YuNet.py
+++ b/deepface/models/face_detection/YuNet.py
@@ -67,10 +67,11 @@ class YuNetClient(Detector):
         Returns:
             results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): A list or a list of lists of FacialAreaRegion objects
         """
-        if not isinstance(img, list):
+        is_batched_input = isinstance(img, list)
+        if not is_batched_input:
             img = [img]
         results = [self._process_single_image(single_img) for single_img in img]
-        if len(results) == 1:
+        if not is_batched_input:
             return results[0]
         return results
 

--- a/deepface/models/face_detection/YuNet.py
+++ b/deepface/models/face_detection/YuNet.py
@@ -1,6 +1,6 @@
 # built-in dependencies
 import os
-from typing import Any, List
+from typing import Any, List, Union
 
 # 3rd party dependencies
 import cv2
@@ -57,9 +57,26 @@ class YuNetClient(Detector):
             ) from err
         return face_detector
 
-    def detect_faces(self, img: np.ndarray) -> List[FacialAreaRegion]:
+    def detect_faces(self, img: Union[np.ndarray, List[np.ndarray]]) -> Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]:
         """
         Detect and align face with yunet
+
+        Args:
+            img (Union[np.ndarray, List[np.ndarray]]): pre-loaded image as numpy array or a list of those
+
+        Returns:
+            results (Union[List[FacialAreaRegion], List[List[FacialAreaRegion]]]): A list or a list of lists of FacialAreaRegion objects
+        """
+        if isinstance(img, np.ndarray):
+            return self._process_single_image(img)
+        elif isinstance(img, list):
+            return [self._process_single_image(single_img) for single_img in img]
+        else:
+            raise ValueError("Input must be a numpy array or a list of numpy arrays.")
+
+    def _process_single_image(self, img: np.ndarray) -> List[FacialAreaRegion]:
+        """
+        Helper function to detect faces in a single image.
 
         Args:
             img (np.ndarray): pre-loaded image as numpy array

--- a/deepface/modules/detection.py
+++ b/deepface/modules/detection.py
@@ -1,5 +1,5 @@
 # built-in dependencies
-from typing import Any, Dict, IO, List, Tuple, Union, Optional
+from typing import Any, Dict, IO, List, Tuple, Union, Optional, Sequence
 
 # 3rd part dependencies
 from heapq import nlargest
@@ -19,7 +19,7 @@ logger = Logger()
 
 
 def extract_faces(
-    img_path: Union[List[Union[str, np.ndarray, IO[bytes]]], str, np.ndarray, IO[bytes]],
+    img_path: Union[Sequence[Union[str, np.ndarray, IO[bytes]]], str, np.ndarray, IO[bytes]],
     detector_backend: str = "opencv",
     enforce_detection: bool = True,
     align: bool = True,

--- a/deepface/modules/detection.py
+++ b/deepface/modules/detection.py
@@ -82,6 +82,8 @@ def extract_faces(
             just available in the result only if anti_spoofing is set to True in input arguments.
     """
 
+    if isinstance(img_path, np.ndarray) and img_path.ndim == 4:
+        img_path = [img_path[i] for i in range(img_path.shape[0])]
     if not isinstance(img_path, list):
         img_path = [img_path]
 

--- a/deepface/modules/detection.py
+++ b/deepface/modules/detection.py
@@ -29,7 +29,7 @@ def extract_faces(
     normalize_face: bool = True,
     anti_spoofing: bool = False,
     max_faces: Optional[int] = None,
-) -> List[Dict[str, Any]]:
+) -> Union[List[Dict[str, Any]], List[List[Dict[str, Any]]]]:
     """
     Extract faces from a given image or list of images
 
@@ -62,7 +62,8 @@ def extract_faces(
         anti_spoofing (boolean): Flag to enable anti spoofing (default is False).
 
     Returns:
-        results (List[Dict[str, Any]]): A list of dictionaries, where each dictionary contains:
+        results (Union[List[Dict[str, Any]], List[List[Dict[str, Any]]]): 
+        A list or list of lists of dictionaries, where each dictionary contains:
 
         - "face" (np.ndarray): The detected face as a NumPy array in RGB format.
 
@@ -131,6 +132,7 @@ def extract_faces(
             base_region = FacialAreaRegion(x=0, y=0, w=width, h=height, confidence=0)
             face_objs = [DetectedFace(img=img, facial_area=base_region, confidence=0)]
 
+        img_resp_objs = []
         for face_obj in face_objs:
             current_img = face_obj.img
             current_region = face_obj.facial_area
@@ -195,8 +197,12 @@ def extract_faces(
                 resp_obj["is_real"] = is_real
                 resp_obj["antispoof_score"] = antispoof_score
 
-            all_resp_objs.append(resp_obj)
+            img_resp_objs.append(resp_obj)
 
+        all_resp_objs.append(img_resp_objs)
+
+    if len(all_resp_objs) == 1:
+        return all_resp_objs[0]
     return all_resp_objs
 
 

--- a/deepface/modules/detection.py
+++ b/deepface/modules/detection.py
@@ -84,7 +84,7 @@ def extract_faces(
 
     batched_input = (
         (
-            isinstance(img_path, np.ndarray) and 
+            isinstance(img_path, np.ndarray) and
             img_path.ndim == 4
         ) or isinstance(img_path, list)
     )
@@ -246,7 +246,7 @@ def detect_faces(
     """
     batched_input = (
         (
-            isinstance(img, np.ndarray) and 
+            isinstance(img, np.ndarray) and
             img.ndim == 4
         ) or isinstance(img, list)
     )

--- a/deepface/modules/detection.py
+++ b/deepface/modules/detection.py
@@ -34,8 +34,9 @@ def extract_faces(
     Extract faces from a given image or list of images
 
     Args:
-        img_paths (List[str or np.ndarray or IO[bytes]] or str or np.ndarray or IO[bytes]): Path(s) to the image(s). Accepts exact image path
-            as a string, numpy array (BGR), a file object that supports at least `.read` and is
+        img_paths (List[str or np.ndarray or IO[bytes]] or str or np.ndarray or IO[bytes]): 
+            Path(s) to the image(s) as a string, 
+            numpy array (BGR), a file object that supports at least `.read` and is
             opened in binary mode, or base64 encoded images.
 
         detector_backend (string): face detector backend. Options: 'opencv', 'retinaface',
@@ -148,7 +149,10 @@ def extract_faces(
                 elif color_face == "gray":
                     current_img = cv2.cvtColor(current_img, cv2.COLOR_BGR2GRAY)
                 else:
-                    raise ValueError(f"The color_face can be rgb, bgr or gray, but it is {color_face}.")
+                    raise ValueError(
+                        f"The color_face can be rgb, bgr or gray, "
+                        f"but it is {color_face}."
+                    )
 
             if normalize_face:
                 current_img = current_img / 255  # normalize input in [0, 1]
@@ -184,7 +188,10 @@ def extract_faces(
 
             if anti_spoofing is True:
                 antispoof_model = modeling.build_model(task="spoofing", model_name="Fasnet")
-                is_real, antispoof_score = antispoof_model.analyze(img=img, facial_area=(x, y, w, h))
+                is_real, antispoof_score = antispoof_model.analyze(
+                    img=img,
+                    facial_area=(x, y, w, h)
+                )
                 resp_obj["is_real"] = is_real
                 resp_obj["antispoof_score"] = antispoof_score
 
@@ -226,10 +233,18 @@ def detect_faces(
     """
     if not isinstance(img, list):
         img = [img]
-    
+
     if detector_backend == "skip":
         all_face_objs = [
-            [DetectedFace(img=single_img, facial_area=FacialAreaRegion(x=0, y=0, w=single_img.shape[1], h=single_img.shape[0]), confidence=0)]
+            [
+                DetectedFace(
+                    img=single_img,
+                    facial_area=FacialAreaRegion(
+                        x=0, y=0, w=single_img.shape[1], h=single_img.shape[0]
+                    ),
+                    confidence=0,
+                )
+            ]
             for single_img in img
         ]
         if len(img) == 1:
@@ -280,7 +295,17 @@ def detect_faces(
         all_facial_areas = [all_facial_areas]
 
     all_detected_faces = []
-    for single_img, facial_areas, width_border, height_border in zip(preprocessed_images, all_facial_areas, width_borders, height_borders):
+    for (
+        single_img,
+        facial_areas,
+        width_border,
+        height_border
+    ) in zip(
+        preprocessed_images,
+        all_facial_areas,
+        width_borders,
+        height_borders
+    ):
         if not isinstance(facial_areas, list):
             facial_areas = [facial_areas]
 

--- a/deepface/modules/detection.py
+++ b/deepface/modules/detection.py
@@ -226,6 +226,15 @@ def detect_faces(
     """
     if not isinstance(img, list):
         img = [img]
+    
+    if detector_backend == "skip":
+        all_face_objs = [
+            [DetectedFace(img=single_img, facial_area=FacialAreaRegion(x=0, y=0, w=single_img.shape[1], h=single_img.shape[0]), confidence=0)]
+            for single_img in img
+        ]
+        if len(img) == 1:
+            all_face_objs = all_face_objs[0]
+        return all_face_objs
 
     face_detector: Detector = modeling.build_model(
         task="face_detector", model_name=detector_backend

--- a/tests/test_extract_faces.py
+++ b/tests/test_extract_faces.py
@@ -180,6 +180,7 @@ def test_batch_extract_faces_with_nparray(detector_backend):
         cv2.resize(image_utils.load_image(img_path)[0], (1920, 1080))
         for img_path in img_paths
     ]
+    expected_num_faces = [1, 1, 1, 2]
 
     # load images as numpy arrays
     imgs_batch = np.stack(imgs, axis=0)
@@ -191,6 +192,9 @@ def test_batch_extract_faces_with_nparray(detector_backend):
         align=True,
         enforce_detection=False,
     )
+    assert len(imgs_objs_batch) == 4
+    for img_objs_batch, expected_num_faces in zip(imgs_objs_batch, expected_num_faces):
+        assert len(img_objs_batch) == expected_num_faces
 
     # extract faces in batch of paths
     imgs_objs_batch_paths = DeepFace.extract_faces(

--- a/tests/test_extract_faces.py
+++ b/tests/test_extract_faces.py
@@ -106,6 +106,12 @@ def test_batch_extract_faces(detector_backend):
         align=True,
     )
     
+    assert (
+        len(img_objs_batch) == 3 and 
+        all(isinstance(obj, list) and len(obj) == 1 for obj in img_objs_batch)
+    )
+    img_objs_batch = [obj for sublist in img_objs_batch for obj in sublist]
+    
     assert len(img_objs_batch) == len(img_objs_individual)
     
     for img_obj_individual, img_obj_batch in zip(img_objs_individual, img_objs_batch):

--- a/tests/test_extract_faces.py
+++ b/tests/test_extract_faces.py
@@ -217,7 +217,7 @@ def test_batch_extract_faces_with_nparray(detector_backend):
     )
 
     # Check that the batch extraction returned the expected number of face lists
-    assert len(imgs_objs_batch) == 4
+    assert len(imgs_objs_batch) == len(img_paths)
     for img_objs_batch, img_expected_num_faces in zip(imgs_objs_batch, expected_num_faces):
         assert len(img_objs_batch) == img_expected_num_faces
 

--- a/tests/test_extract_faces.py
+++ b/tests/test_extract_faces.py
@@ -207,6 +207,16 @@ def test_batch_extract_faces_with_nparray(detector_backend):
         )
 
 
+def test_batch_extract_faces_single_image():
+    img_path = "dataset/couple.jpg"
+    imgs_objs_batch = DeepFace.extract_faces(
+        img_path=[img_path],
+        align=True,
+    )
+    assert len(imgs_objs_batch) == 2
+    assert [isinstance(obj, dict) for obj in imgs_objs_batch]
+
+
 def test_backends_for_enforced_detection_with_non_facial_inputs():
     black_img = np.zeros([224, 224, 3])
     for detector in detectors:

--- a/tests/test_extract_faces.py
+++ b/tests/test_extract_faces.py
@@ -242,8 +242,8 @@ def test_batch_extract_faces_single_image():
         img_path=[img_path],
         align=True,
     )
-    assert len(imgs_objs_batch) == 2
-    assert [isinstance(obj, dict) for obj in imgs_objs_batch]
+    assert len(imgs_objs_batch) == 1 and isinstance(imgs_objs_batch[0], list)
+    assert [isinstance(obj, dict) for obj in imgs_objs_batch[0]]
 
 
 def test_backends_for_enforced_detection_with_non_facial_inputs():

--- a/tests/test_extract_faces.py
+++ b/tests/test_extract_faces.py
@@ -157,6 +157,56 @@ def test_batch_extract_faces(detector_backend):
             ) <= rtol * img_obj_individual["confidence"]
     
 
+@pytest.mark.parametrize("detector_backend", [
+    "opencv",
+    "ssd",
+    "mtcnn",
+    "retinaface",
+    "yunet",
+    "centerface",
+    # optional
+    # "yolov11s",
+    # "mediapipe",
+    # "dlib",
+])
+def test_batch_extract_faces_with_nparray(detector_backend):
+    img_paths = [
+        "dataset/img2.jpg",
+        "dataset/img3.jpg",
+        "dataset/img11.jpg",
+        "dataset/couple.jpg"
+    ]
+    imgs = [
+        cv2.resize(image_utils.load_image(img_path)[0], (1920, 1080))
+        for img_path in img_paths
+    ]
+
+    # load images as numpy arrays
+    imgs_batch = np.stack(imgs, axis=0)
+
+    # extract faces in batch of numpy arrays
+    imgs_objs_batch = DeepFace.extract_faces(
+        img_path=imgs_batch,
+        detector_backend=detector_backend,
+        align=True,
+        enforce_detection=False,
+    )
+
+    # extract faces in batch of paths
+    imgs_objs_batch_paths = DeepFace.extract_faces(
+        img_path=imgs,
+        detector_backend=detector_backend,
+        align=True,
+        enforce_detection=False,
+    )
+
+    # compare results
+    for img_objs_batch, img_objs_batch_paths in zip(imgs_objs_batch, imgs_objs_batch_paths):
+        assert len(img_objs_batch) == len(img_objs_batch_paths), (
+            "Batch and individual extraction results should have the same number of detected faces"
+        )
+
+
 def test_backends_for_enforced_detection_with_non_facial_inputs():
     black_img = np.zeros([224, 224, 3])
     for detector in detectors:

--- a/tests/test_extract_faces.py
+++ b/tests/test_extract_faces.py
@@ -80,7 +80,7 @@ def test_different_detectors():
 
 
 @pytest.mark.parametrize("detector_backend", [
-    # "YOLO",
+    "yolov11n",
     "opencv",
 ])
 def test_batch_extract_faces(detector_backend):
@@ -89,8 +89,19 @@ def test_batch_extract_faces(detector_backend):
         "dataset/img3.jpg",
         "dataset/img11.jpg",
     ]
-    img_objs = DeepFace.extract_faces(img_path=img_paths, detector_backend=detector_backend)
-    assert len(img_objs) == 3
+    
+    # Extract faces one by one
+    img_objs_individual = [DeepFace.extract_faces(img_path=img_path, detector_backend=detector_backend)[0] for img_path in img_paths]
+    
+    # Extract faces in batch
+    img_objs_batch = DeepFace.extract_faces(img_path=img_paths, detector_backend=detector_backend)
+    
+    assert len(img_objs_batch) == len(img_objs_individual)
+    
+    for img_obj_individual, img_obj_batch in zip(img_objs_individual, img_objs_batch):
+        assert np.array_equal(img_obj_individual["face"], img_obj_batch["face"])
+        assert img_obj_individual["facial_area"] == img_obj_batch["facial_area"]
+        assert img_obj_individual["confidence"] == img_obj_batch["confidence"]
 
 
 def test_backends_for_enforced_detection_with_non_facial_inputs():

--- a/tests/test_extract_faces.py
+++ b/tests/test_extract_faces.py
@@ -79,6 +79,20 @@ def test_different_detectors():
         logger.info(f"✅ extract_faces for {detector} backend test is done")
 
 
+@pytest.mark.parametrize("detector_backend", [
+    # "YOLO",
+    "opencv",
+])
+def test_batch_extract_faces(detector_backend):
+    img_paths = [
+        "dataset/img2.jpg",
+        "dataset/img3.jpg",
+        "dataset/img11.jpg",
+    ]
+    img_objs = DeepFace.extract_faces(img_path=img_paths, detector_backend=detector_backend)
+    assert len(img_objs) == 3
+
+
 def test_backends_for_enforced_detection_with_non_facial_inputs():
     black_img = np.zeros([224, 224, 3])
     for detector in detectors:

--- a/tests/test_extract_faces.py
+++ b/tests/test_extract_faces.py
@@ -104,6 +104,7 @@ def test_batch_extract_faces(detector_backend):
         "dataset/img11.jpg",
         "dataset/couple.jpg"
     ]
+    expected_num_faces = [1, 1, 1, 2]
     
     # Extract faces one by one
     imgs_objs_individual = [
@@ -121,15 +122,12 @@ def test_batch_extract_faces(detector_backend):
         align=True,
     )
     
-    assert (
-        len(imgs_objs_batch) == 4 and 
-        all(isinstance(obj, list) for obj in imgs_objs_batch)
-    )
-    assert all(
-        len(imgs_objs_batch[i]) == 1 
-        for i in range(len(imgs_objs_batch[:-1]))
-    )
-    assert len(imgs_objs_batch[-1]) == 2
+    # Check that the batch extraction returned the expected number of face lists
+    assert len(imgs_objs_batch) == len(img_paths)
+    
+    # Check that each face list has the expected number of faces
+    for i, expected_faces in enumerate(expected_num_faces):
+        assert len(imgs_objs_batch[i]) == expected_faces
 
     for img_objs_individual, img_objs_batch in zip(imgs_objs_individual, imgs_objs_batch):
         assert len(img_objs_batch) == len(img_objs_individual), (

--- a/tests/test_extract_faces.py
+++ b/tests/test_extract_faces.py
@@ -23,6 +23,10 @@ def test_different_detectors():
 
     for detector in detectors:
         img_objs = DeepFace.extract_faces(img_path=img_path, detector_backend=detector)
+
+        # Check return type for non-batch input
+        assert isinstance(img_objs, list) and all(isinstance(obj, dict) for obj in img_objs)
+
         for img_obj in img_objs:
             assert "face" in img_obj.keys()
             assert "facial_area" in img_obj.keys()
@@ -114,6 +118,15 @@ def test_batch_extract_faces(detector_backend):
             align=True,
         ) for img_path in img_paths
     ]
+
+    # Check that individual extraction returns a list of faces
+    for img_objs_individual in imgs_objs_individual:
+        assert isinstance(img_objs_individual, list)
+        assert all(isinstance(face, dict) for face in img_objs_individual)
+
+    # Check that the individual extraction results match the expected number of faces
+    for img_objs_individual, expected_faces in zip(imgs_objs_individual, expected_num_faces):
+        assert len(img_objs_individual) == expected_faces
     
     # Extract faces in batch
     imgs_objs_batch = DeepFace.extract_faces(
@@ -129,6 +142,7 @@ def test_batch_extract_faces(detector_backend):
     for i, expected_faces in enumerate(expected_num_faces):
         assert len(imgs_objs_batch[i]) == expected_faces
 
+    # Check that the individual extraction results match the batch extraction results
     for img_objs_individual, img_objs_batch in zip(imgs_objs_individual, imgs_objs_batch):
         assert len(img_objs_batch) == len(img_objs_individual), (
             "Batch and individual extraction results should have the same number of detected faces"
@@ -190,6 +204,18 @@ def test_batch_extract_faces_with_nparray(detector_backend):
         align=True,
         enforce_detection=False,
     )
+
+    # Check return type for batch input
+    assert (
+        isinstance(imgs_objs_batch, list) and 
+        all(
+            isinstance(obj, list) and 
+            all(isinstance(face, dict) for face in obj) 
+            for obj in imgs_objs_batch
+        )
+    )
+
+    # Check that the batch extraction returned the expected number of face lists
     assert len(imgs_objs_batch) == 4
     for img_objs_batch, expected_num_faces in zip(imgs_objs_batch, expected_num_faces):
         assert len(img_objs_batch) == expected_num_faces

--- a/tests/test_extract_faces.py
+++ b/tests/test_extract_faces.py
@@ -84,15 +84,20 @@ def test_different_detectors():
     "ssd",
     "mtcnn",
     "retinaface",
+    "yunet",
+    "centerface",
+    # optional
+    # "yolov11s",
+    # "mediapipe",
+    # "dlib",
 ])
 def test_batch_extract_faces(detector_backend):
     detector_backend_to_rtol = {
         "opencv": 0.1,
-        "ssd": 0.01,
         "mtcnn": 0.2,
-        "retinaface": 0.01,
+        "yolov11s": 0.03,
     }
-    rtol = detector_backend_to_rtol[detector_backend]
+    rtol = detector_backend_to_rtol.get(detector_backend, 0.01)
     img_paths = [
         "dataset/img2.jpg",
         "dataset/img3.jpg",

--- a/tests/test_extract_faces.py
+++ b/tests/test_extract_faces.py
@@ -84,7 +84,7 @@ def test_different_detectors():
 
 
 @pytest.mark.parametrize("detector_backend", [
-    "opencv",
+    # "opencv",
     "ssd",
     "mtcnn",
     "retinaface",

--- a/tests/test_extract_faces.py
+++ b/tests/test_extract_faces.py
@@ -96,12 +96,8 @@ def test_different_detectors():
     # "dlib",
 ])
 def test_batch_extract_faces(detector_backend):
-    detector_backend_to_rtol = {
-        "opencv": 0.1,
-        "mtcnn": 0.2,
-        "yolov11s": 0.03,
-    }
-    rtol = detector_backend_to_rtol.get(detector_backend, 0.01)
+    # Relative tolerance for comparing floating-point values
+    rtol = 0.03
     img_paths = [
         "dataset/img2.jpg",
         "dataset/img3.jpg",
@@ -154,15 +150,20 @@ def test_batch_extract_faces(detector_backend):
                         img_obj_individual["facial_area"][key], 
                         img_obj_batch["facial_area"][key]
                     ):
+                        # Ensure the difference between individual and batch values 
+                        # is within rtol% of the individual value
                         assert abs(ind_val - batch_val) <= rtol * ind_val
                 elif (
                     isinstance(img_obj_individual["facial_area"][key], int) or 
                     isinstance(img_obj_individual["facial_area"][key], float)
                 ):
+                    # Ensure the difference between individual and batch values 
+                    # is within rtol% of the individual value
                     assert abs(
                         img_obj_individual["facial_area"][key] - 
                         img_obj_batch["facial_area"][key]
                     ) <= rtol * img_obj_individual["facial_area"][key]
+            # Ensure the confidence difference is within rtol% of the individual confidence
             assert abs(
                 img_obj_individual["confidence"] - 
                 img_obj_batch["confidence"]
@@ -175,7 +176,7 @@ def test_batch_extract_faces(detector_backend):
     "mtcnn",
     "retinaface",
     "yunet",
-    "centerface",
+    # "centerface",
     # optional
     # "yolov11s",
     # "mediapipe",
@@ -217,8 +218,8 @@ def test_batch_extract_faces_with_nparray(detector_backend):
 
     # Check that the batch extraction returned the expected number of face lists
     assert len(imgs_objs_batch) == 4
-    for img_objs_batch, expected_num_faces in zip(imgs_objs_batch, expected_num_faces):
-        assert len(img_objs_batch) == expected_num_faces
+    for img_objs_batch, img_expected_num_faces in zip(imgs_objs_batch, expected_num_faces):
+        assert len(img_objs_batch) == img_expected_num_faces
 
     # extract faces in batch of paths
     imgs_objs_batch_paths = DeepFace.extract_faces(

--- a/tests/test_extract_faces.py
+++ b/tests/test_extract_faces.py
@@ -80,10 +80,8 @@ def test_different_detectors():
 
 
 @pytest.mark.parametrize("detector_backend", [
-    # "yolov11n",
-    # "yolov8",
-    "yolov11s",
-    # "opencv",
+    "opencv",
+    "ssd"
 ])
 def test_batch_extract_faces(detector_backend):
     img_paths = [


### PR DESCRIPTION
## Tickets

https://github.com/serengil/deepface/pull/1433
https://github.com/serengil/deepface/issues/1101
https://github.com/serengil/deepface/issues/1434

### What has been done

With this PR, `.extract_faces` is able to accept a list of images

## How to test

```shell
make lint && make test
```

Benchmarking on detecting 50 faces:
![image](https://github.com/user-attachments/assets/258cab80-08ca-4e3c-b0e4-a19f933a83b6)

For yolov11n, batch size 20 is 59.27% faster than batch size 1.
For yolov11s, batch size 20 is 29.00% faster than batch size 1.
For yolov11m, batch size 20 is 31.73% faster than batch size 1.
For yolov8, batch size 20 is 12.68% faster than batch size 1.