### PR TITLE
allow 0 (as integers) when using pre-calculated embeddings in verify

### DIFF
--- a/deepface/modules/verification.py
+++ b/deepface/modules/verification.py
@@ -141,7 +141,8 @@ def verify(
         """
         if isinstance(img_path, list):
             # given image is already pre-calculated embedding
-            if not all(isinstance(dim, float) for dim in img_path):
+            if not all(isinstance(dim, (float, int)) for dim in img_path):
+
                 raise ValueError(
                     f"When passing img{index}_path as a list,"
                     " ensure that all its items are of type float."


### PR DESCRIPTION
## Tickets

(No ticket has been opened since it's a small edge case.)

First of all, I'd like to thank you for the amazing work you've done with DeepFace! It's an incredibly useful library so far with incredible successful results.

While working with pre-calculated embeddings and calling the DeepFace API from JavaScript, I encountered a small issue. Since JavaScript does not allow the creation of JSON objects with 0.0 (floating point 0), I needed to update the check in the code to allow 0 as a valid value alongside float values.


### What has been done

- Iterate once over img_path (as done before with _all_)
- Check if each value is either a float or 0.
- Convert the values to float as needed, including 0 (which will be converted to 0.0).

## How to test

```shell
make lint && make test
```