### PR TITLE
Update VGGFace.py

### DIFF
--- a/deepface/models/facial_recognition/VGGFace.py
+++ b/deepface/models/facial_recognition/VGGFace.py
@@ -161,6 +161,6 @@ def load_model(
     # base_model_output = Lambda(lambda x: K.l2_normalize(x, axis=1), name="norm_layer")(
     #     base_model_output
     # )
-    vgg_face_descriptor = Model(inputs=model.input, outputs=base_model_output)
+    vgg_face_descriptor = Model(inputs=model.layers[0].input, outputs=base_model_output)
 
     return vgg_face_descriptor


### PR DESCRIPTION
Tensorflow versions > 2.13 give error: AttributeError: The layer sequential has never been called and thus has no defined input.

This is solved by replacing `model.input` by `model.layers[0].input`

## Tickets

https://github.com/serengil/deepface/issues/1380

## How to test

```shell
make lint && make test
```