### PR TITLE
fix: typo in error message for missing pytorch

### DIFF
--- a/deepface/models/spoofing/FasNet.py
+++ b/deepface/models/spoofing/FasNet.py
@@ -29,7 +29,7 @@ class Fasnet:
             import torch
         except Exception as err:
             raise ValueError(
-                "You must install torch with `pip install pytorch` command to use face anti spoofing module"
+                "You must install torch with `pip install torch` command to use face anti spoofing module"
             ) from err
 
         device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")


### PR DESCRIPTION
## Tickets

https://github.com/serengil/deepface/issues/1462

### What has been done

With this PR, 
fix typo of pytorch installation instruction