### PR TITLE
Resolve warnings of Logger library

### DIFF
--- a/deepface/DeepFace.py
+++ b/deepface/DeepFace.py
@@ -635,7 +635,7 @@ def detectFace(
     Returns:
         img (np.ndarray): detected (and aligned) facial area image as numpy array
     """
-    logger.warn("Function detectFace is deprecated. Use extract_faces instead.")
+    logger.warning("Function detectFace is deprecated. Use extract_faces instead.")
     face_objs = extract_faces(
         img_path=img_path,
         detector_backend=detector_backend,

--- a/deepface/modules/detection.py
+++ b/deepface/modules/detection.py
@@ -128,7 +128,7 @@ def extract_faces(
             continue
 
         if grayscale is True:
-            logger.warn("Parameter grayscale is deprecated. Use color_face instead.")
+            logger.warning("Parameter grayscale is deprecated. Use color_face instead.")
             current_img = cv2.cvtColor(current_img, cv2.COLOR_BGR2GRAY)
         else:
             if color_face == "rgb":
@@ -226,7 +226,7 @@ def detect_faces(
 
     # validate expand percentage score
     if expand_percentage < 0:
-        logger.warn(
+        logger.warning(
             f"Expand percentage cannot be negative but you set it to {expand_percentage}."
             "Overwritten it to 0."
         )
@@ -304,7 +304,7 @@ def extract_face(
     if align is True:  # and left_eye is not None and right_eye is not None:
         # we were aligning the original image before, but this comes with an extra cost
         # instead we now focus on the facial area with a margin
-        # and align it instead of original image to decrese the cost
+        # and align it instead of original image to decrease the cost
         sub_img, relative_x, relative_y = extract_sub_image(img=img, facial_area=(x, y, w, h))
 
         aligned_sub_img, angle = align_img_wrt_eyes(
@@ -419,7 +419,7 @@ def align_img_wrt_eyes(
     right_eye: Optional[Union[list, tuple]],
 ) -> Tuple[np.ndarray, float]:
     """
-    Align a given image horizantally with respect to their left and right eye locations
+    Align a given image horizontally with respect to their left and right eye locations
     Args:
         img (np.ndarray): pre-loaded image with detected face
         left_eye (list or tuple): coordinates of left eye with respect to the person itself
@@ -453,7 +453,7 @@ def project_facial_area(
     """
     Update pre-calculated facial area coordinates after image itself
         rotated with respect to the eyes.
-    Inspried from the work of @UmutDeniz26 - github.com/serengil/retinaface/pull/80
+    Inspired from the work of @UmutDeniz26 - github.com/serengil/retinaface/pull/80
 
     Args:
         facial_area (tuple of int): Representing the (x1, y1, x2, y2) of the facial area.
@@ -467,7 +467,7 @@ def project_facial_area(
             (x1, y1, x2, y2) or (x1, y1, x1+w1, y1+h1) of the rotated facial area.
     """
 
-    # Normalize the witdh of the angle so we don't have to
+    # Normalize the width of the angle so we don't have to
     # worry about rotations greater than 360 degrees.
     # We workaround the quirky behavior of the modulo operator
     # for negative angle values.

--- a/deepface/modules/streaming.py
+++ b/deepface/modules/streaming.py
@@ -142,7 +142,7 @@ def analysis(
             if freeze:
                 frame += 1
 
-                # restore raw image to get rid of countdown informtion
+                # restore raw image to get rid of countdown information
                 img = raw_img.copy()
 
                 # add analyze results into img
@@ -197,7 +197,7 @@ def analysis(
             tic = time.time()
             logger.info("Freeze released")
 
-        # count how many seconds required to relased freezed image in the left up area
+        # count how many seconds required to released freezed image in the left up area
         freezed_img = countdown_to_release(img=freezed_img, tic=tic, time_threshold=time_threshold)
         display_img = img if freezed_img is None else freezed_img
 
@@ -267,7 +267,7 @@ def search_identity(
         )
     except ValueError as err:
         if f"No item found in {db_path}" in str(err):
-            logger.warn(
+            logger.warning(
                 f"No item is found in {db_path}."
                 "So, no facial recognition analysis will be performed."
             )
@@ -371,8 +371,8 @@ def countdown_to_freeze(
     Args:
         img (np.ndarray): image itself
         faces_coordinates (list): list of face coordinates as tuple with x, y, w and h
-        frame_threshold (int): how many sequantial frames required with face(s) to freeze
-        num_frames_with_faces (int): how many sequantial frames do we have with face(s)
+        frame_threshold (int): how many sequential frames required with face(s) to freeze
+        num_frames_with_faces (int): how many sequential frames do we have with face(s)
     Returns:
         img (np.ndarray): image with counter values
     """
@@ -503,7 +503,7 @@ def perform_facial_recognition(
         model_name (str): Model for face recognition. Options: VGG-Face, Facenet, Facenet512,
             OpenFace, DeepFace, DeepID, Dlib, ArcFace, SFace and GhostFaceNet (default is VGG-Face).
     Returns:
-        img (np.ndarray): image with identified face informations
+        img (np.ndarray): image with identified face information
     """
     for idx, (x, y, w, h, is_real, antispoof_score) in enumerate(faces_coordinates):
         detected_face = detected_faces[idx]
@@ -598,7 +598,7 @@ def overlay_identified_face(
         w (int): w coordinate of the face on the given image
         h (int): h coordinate of the face on the given image
     Returns:
-        img (np.ndarray): image with overlayed identity
+        img (np.ndarray): image with overlaid identity
     """
     try:
         if y - IDENTIFIED_IMG_SIZE > 0 and x + w + IDENTIFIED_IMG_SIZE < img.shape[1]:
@@ -767,7 +767,7 @@ def overlay_identified_face(
             x + w + IDENTIFIED_IMG_SIZE < img.shape[1]
             and y + h + IDENTIFIED_IMG_SIZE < img.shape[0]
         ):
-            # bottom righ
+            # bottom right
             img[
                 y + h : y + h + IDENTIFIED_IMG_SIZE,
                 x + w : x + w + IDENTIFIED_IMG_SIZE,

--- a/deepface/modules/verification.py
+++ b/deepface/modules/verification.py
@@ -149,7 +149,7 @@ def verify(
                 )
 
             if silent is False:
-                logger.warn(
+                logger.warning(
                     f"You passed {index}-th image as pre-calculated embeddings."
                     "Please ensure that embeddings have been calculated"
                     f" for the {model_name} model."

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -442,7 +442,7 @@ def is_form_data_file_testable() -> bool:
     threshold_version = version.parse("2.0.2")
     is_testable = flask_version <= threshold_version and werkzeus_version <= threshold_version
     if is_testable is False:
-        logger.warn(
+        logger.warning(
             "sending file in form data is not testable because of flask, werkzeus versions."
             f"Expected <= {threshold_version}, but {flask_version=} and {werkzeus_version}."
         )


### PR DESCRIPTION
## Tickets

### What has been done
This PR resolves the deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
It also fixes a few typos along the way.