### PR TITLE
Fix AttributeError in streaming

### DIFF
--- a/deepface/modules/streaming.py
+++ b/deepface/modules/streaming.py
@@ -110,10 +110,10 @@ def analysis(
 
     while True:
         has_frame, img = cap.read()
-        raw_img = img.copy()
-
         if not has_frame:
             break
+
+        raw_img = img.copy()
 
         faces_coordinates = []
 


### PR DESCRIPTION
### What has been done

Very, very minor bug fix. Moved the `img.copy()` to be down after the `has_frame` check. 

Without it, when you're done processing the video, you'll get an error accessing copy on None:

```
Traceback (most recent call last):
  File "/Users/catcai/go/src/github.com/catherinetcai/face-recog-tests/main.py", line 43, in <module>
    main()
  File "/Users/catcai/go/src/github.com/catherinetcai/face-recog-tests/main.py", line 12, in main
    DeepFace.stream(db_path=DB_PATH, source=VIDEO, output_path=OUTPUT_PATH, debug=True)
  File "/Users/catcai/go/src/github.com/catherinetcai/face-recog-tests/.venv/lib/python3.12/site-packages/deepface/DeepFace.py", line 508, in stream
    streaming.analysis(
  File "/Users/catcai/go/src/github.com/catherinetcai/face-recog-tests/.venv/lib/python3.12/site-packages/deepface/modules/streaming.py", line 113, in analysis
    raw_img = img.copy()
              ^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'copy'
```