### PR TITLE
Diagram visualization of the deepface codebase

### DIFF
--- a/.codeboarding/External_Integration_Layer.md
+++ b/.codeboarding/External_Integration_Layer.md
@@ -1,0 +1,163 @@
+```mermaid
+
+graph LR
+
+    API_Core["API Core"]
+
+    Streaming_Module["Streaming Module"]
+
+    DeepFace_Facade["DeepFace Facade"]
+
+    Common_Utilities["Common Utilities"]
+
+    Models["Models"]
+
+    API_Core -- "delegates requests to" --> DeepFace_Facade
+
+    Streaming_Module -- "delegates requests to" --> DeepFace_Facade
+
+    API_Core -- "uses" --> Common_Utilities
+
+    Streaming_Module -- "uses" --> Common_Utilities
+
+    DeepFace_Facade -- "interacts with to manage and utilize" --> Models
+
+    DeepFace_Facade -- "uses for logging and image processing" --> Common_Utilities
+
+    Common_Utilities -- "provides services to" --> API_Core
+
+    Common_Utilities -- "provides services to" --> DeepFace_Facade
+
+    Common_Utilities -- "provides services to" --> Streaming_Module
+
+    Models -- "are used by" --> DeepFace_Facade
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The `External Integration Layer` is a crucial component that acts as the primary interface between the DeepFace library and external applications or systems. It is designed to expose DeepFace's powerful facial analysis capabilities through well-defined interaction patterns, specifically a RESTful API and a real-time streaming module. This layer is fundamental because it enables DeepFace to be integrated into a wide array of applications, such as web services, mobile applications, or live video surveillance systems, without requiring direct Python code interaction from the external system.
+
+
+
+### API Core
+
+This component is responsible for handling all REST API interactions. It defines the various endpoints that external systems can call to access DeepFace functionalities (e.g., face verification, analysis, detection). It manages the parsing of incoming HTTP requests, validates the input data, orchestrates the calls to the underlying DeepFace functionalities, and formats the responses before sending them back to the client. It essentially translates HTTP requests into DeepFace operations and vice-versa.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/api/src/api.py#L1-L1" target="_blank" rel="noopener noreferrer">`deepface.api.src.api` (1:1)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/api/src/app.py#L1-L1" target="_blank" rel="noopener noreferrer">`deepface.api.src.app` (1:1)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/api/src/modules/core/routes.py#L1-L1" target="_blank" rel="noopener noreferrer">`deepface.api.src.modules.core.routes` (1:1)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/api/src/modules/core/service.py#L1-L1" target="_blank" rel="noopener noreferrer">`deepface.api.src.modules.core.service` (1:1)</a>
+
+
+
+
+
+### Streaming Module
+
+This component specializes in processing real-time video streams for continuous facial analysis. It handles the ingestion of video frames, applies DeepFace's face detection, recognition, and demography analysis algorithms to each frame, and can output the results in a continuous manner. This is essential for applications requiring live monitoring or interactive facial analysis.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/modules/streaming.py#L1-L1" target="_blank" rel="noopener noreferrer">`deepface.modules.streaming` (1:1)</a>
+
+
+
+
+
+### DeepFace Facade
+
+This component serves as the central entry point and a simplified interface to the core DeepFace functionalities. It orchestrates calls to various internal DeepFace modules (e.g., for facial representation, verification, analysis, detection, and model management). It abstracts away the complexity of the underlying deep learning models and their specific implementations, providing a clean and consistent API for higher-level components like the `API Core` and `Streaming Module`.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/DeepFace.py#L1-L1" target="_blank" rel="noopener noreferrer">`deepface.DeepFace` (1:1)</a>
+
+
+
+
+
+### Common Utilities
+
+This component provides a collection of shared utility functions and helper modules that are utilized across various parts of the DeepFace project, including the `External Integration Layer`. Key functionalities include robust logging for debugging and monitoring, and efficient image handling (loading, preprocessing, manipulation) which is critical for any image-based deep learning application.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/commons/logger.py#L1-L1" target="_blank" rel="noopener noreferrer">`deepface.commons.logger` (1:1)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/commons/image_utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`deepface.commons.image_utils` (1:1)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/commons/package_utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`deepface.commons.package_utils` (1:1)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/commons/folder_utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`deepface.commons.folder_utils` (1:1)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/commons/weight_utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`deepface.commons.weight_utils` (1:1)</a>
+
+
+
+
+
+### Models
+
+This component is responsible for defining, loading, and managing the various deep learning models used by DeepFace for its core tasks, such as facial recognition, face detection, and demography analysis (age, gender, emotion, race). It handles the instantiation and potentially caching of these models to optimize performance.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `deepface.models.demography` (1:1)
+
+- `deepface.models.face_detection` (1:1)
+
+- `deepface.models.facial_recognition` (1:1)
+
+- `deepface.models.spoofing` (1:1)
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Facial_Analysis_Engine.md
+++ b/.codeboarding/Facial_Analysis_Engine.md
@@ -1,0 +1,45 @@
+```mermaid
+
+graph LR
+
+    FaceDetection["FaceDetection"]
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+Initial analysis of the deepface library, focusing on the detection module. Further analysis is needed to identify more components and their relationships across other modules like demography, modeling, and recognition. The current focus is on understanding the core functionalities within detection.py and how they contribute to the overall face analysis process. Future steps will involve analyzing other modules and establishing relationships between them to build a comprehensive understanding of the library's architecture and data flow. The 'referenced_source_code' for 'detect_faces' and 'extract_faces' is a placeholder as the exact line numbers are not yet known without the file content.
+
+
+
+### FaceDetection
+
+Handles face detection functionalities.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/modules/detection.py#L191-L267" target="_blank" rel="noopener noreferrer">`deepface.modules.detection.detect_faces` (191:267)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/modules/detection.py#L20-L188" target="_blank" rel="noopener noreferrer">`deepface.modules.detection.extract_faces` (20:188)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Model_Management_System.md
+++ b/.codeboarding/Model_Management_System.md
@@ -1,0 +1,175 @@
+```mermaid
+
+graph LR
+
+    deepface_modules_modeling["deepface.modules.modeling"]
+
+    deepface_commons_weight_utils["deepface.commons.weight_utils"]
+
+    deepface_models_Demography["deepface.models.Demography"]
+
+    deepface_models_Detector["deepface.models.Detector"]
+
+    deepface_models_FacialRecognition["deepface.models.FacialRecognition"]
+
+    deepface_models_spoofing_FasNet["deepface.models.spoofing.FasNet"]
+
+    deepface_models_spoofing_FasNetBackbone["deepface.models.spoofing.FasNetBackbone"]
+
+    deepface_modules_modeling -- "loads" --> deepface_models_Demography
+
+    deepface_modules_modeling -- "loads" --> deepface_models_Detector
+
+    deepface_modules_modeling -- "loads" --> deepface_models_FacialRecognition
+
+    deepface_modules_modeling -- "loads" --> deepface_models_spoofing_FasNet
+
+    deepface_models_spoofing_FasNet -- "downloads weights via" --> deepface_commons_weight_utils
+
+    deepface_models_spoofing_FasNet -- "builds upon" --> deepface_models_spoofing_FasNetBackbone
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The Model Management System in DeepFace is crucial for handling the diverse range of deep learning models used for facial recognition, detection, demography, and anti-spoofing. It provides a unified and efficient way to load, manage, and utilize these models, abstracting away the underlying complexities of different backends and ensuring pre-trained weights are readily available.
+
+
+
+### deepface.modules.modeling
+
+This module acts as the central orchestrator for the Model Management System. Its primary function, `build_model`, is responsible for dynamically loading and caching various deep learning models (facial recognition, detection, demography, anti-spoofing) based on the requested task and model name. It ensures that models are loaded efficiently, often employing a singleton pattern to reuse already initialized models, thereby providing a unified interface for the rest of the DeepFace system to access pre-trained models.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/modules/modeling.py#L32-L104" target="_blank" rel="noopener noreferrer">`deepface.modules.modeling:build_model` (32:104)</a>
+
+
+
+
+
+### deepface.commons.weight_utils
+
+This utility module is vital for managing pre-trained model weights. Its core function, `download_weights_if_necessary`, handles the downloading, caching, and verification of model weights from external URLs. It supports various compression types and ensures that the necessary model files are available locally before models are loaded, directly addressing the system's need for efficient weight management and utilization.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/commons/weight_utils.py#L27-L76" target="_blank" rel="noopener noreferrer">`deepface.commons.weight_utils:download_weights_if_necessary` (27:76)</a>
+
+
+
+
+
+### deepface.models.Demography
+
+This is an abstract base class that defines the common interface and structure for all demography-related models (e.g., age, gender, emotion, race prediction) within DeepFace. It specifies methods like `predict` and internal preprocessing utilities, ensuring a consistent API for demography models.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/models/Demography.py#L20-L21" target="_blank" rel="noopener noreferrer">`deepface.models.Demography:predict` (20:21)</a>
+
+
+
+
+
+### deepface.models.Detector
+
+This abstract base class defines the common interface and structure for all face detection models (e.g., OpenCV, MTCNN, RetinaFace) within DeepFace. It specifies the `detect_faces` method, which is crucial for locating facial areas in images before further analysis.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/models/Detector.py#L11-L27" target="_blank" rel="noopener noreferrer">`deepface.models.Detector:detect_faces` (11:27)</a>
+
+
+
+
+
+### deepface.models.FacialRecognition
+
+This abstract base class defines the common interface and structure for all facial recognition models (e.g., VGG-Face, FaceNet, ArcFace) within DeepFace. It specifies the `forward` method for generating facial embeddings, which are central to identity verification and recognition tasks.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/models/FacialRecognition.py#L21-L47" target="_blank" rel="noopener noreferrer">`deepface.models.FacialRecognition:forward` (21:47)</a>
+
+
+
+
+
+### deepface.models.spoofing.FasNet
+
+This class represents a concrete implementation of an anti-spoofing model, specifically the Mini Face Anti Spoofing Net. It demonstrates how specific deep learning models are structured, initialized, and integrated into the DeepFace system, including the loading of its specific pre-trained weights and performing anti-spoofing analysis.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/models/spoofing/FasNet.py#L1-L1" target="_blank" rel="noopener noreferrer">`deepface.models.spoofing.FasNet` (1:1)</a>
+
+
+
+
+
+### deepface.models.spoofing.FasNetBackbone
+
+This module defines the core neural network architectures, such as `MiniFASNet`, that serve as the backbone for anti-spoofing models like `FasNet`. It encapsulates the complex convolutional layers, depth-wise separable convolutions, and residual blocks that form the deep learning model's structure.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/models/spoofing/FasNetBackbone.py#L356-L465" target="_blank" rel="noopener noreferrer">`deepface.models.spoofing.FasNetBackbone:MiniFASNet` (356:465)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Utility_Infrastructure_Layer.md
+++ b/.codeboarding/Utility_Infrastructure_Layer.md
@@ -1,0 +1,63 @@
+```mermaid
+
+graph LR
+
+    Utility_Infrastructure_Layer["Utility & Infrastructure Layer"]
+
+    API_Core -- "uses" --> Utility_Infrastructure_Layer
+
+    DeepFace_Facade -- "uses" --> Utility_Infrastructure_Layer
+
+    Streaming_Module -- "uses" --> Utility_Infrastructure_Layer
+
+    Models -- "uses" --> Utility_Infrastructure_Layer
+
+    click Utility_Infrastructure_Layer href "https://github.com/serengil/deepface/blob/main/.codeboarding//Utility_Infrastructure_Layer.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+Analysis of the Utility & Infrastructure Layer within the DeepFace library, detailing its components, purpose, and relationships with other key modules. This layer provides foundational services like image handling, logging, file system operations, and model weight management, which are crucial for the entire DeepFace library's functionality and efficiency. It serves as a bedrock for components such as API Core, DeepFace Facade, Streaming Module, and Models, ensuring reusability and consistency across the application by centralizing common, non-domain-specific functionalities.
+
+
+
+### Utility & Infrastructure Layer
+
+This foundational component provides essential helper functions and cross-cutting concerns used throughout the entire DeepFace library. It includes utilities for image loading and manipulation, centralized logging, file system operations, package-related utilities, constants, and crucially, utilities for managing and loading model weights. It ensures consistency and efficiency for common, non-domain-specific tasks.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/commons/constant.py#L0-L0" target="_blank" rel="noopener noreferrer">`constant` (0:0)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/commons/folder_utils.py#L0-L0" target="_blank" rel="noopener noreferrer">`folder_utils` (0:0)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/commons/image_utils.py#L0-L0" target="_blank" rel="noopener noreferrer">`image_utils` (0:0)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/commons/logger.py#L0-L0" target="_blank" rel="noopener noreferrer">`logger` (0:0)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/commons/package_utils.py#L0-L0" target="_blank" rel="noopener noreferrer">`package_utils` (0:0)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/commons/weight_utils.py#L0-L0" target="_blank" rel="noopener noreferrer">`weight_utils` (0:0)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,219 @@
+```mermaid
+
+graph LR
+
+    DeepFace_Public_API["DeepFace Public API"]
+
+    Model_Management_System["Model Management System"]
+
+    Facial_Analysis_Engine["Facial Analysis Engine"]
+
+    Utility_Infrastructure_Layer["Utility & Infrastructure Layer"]
+
+    External_Integration_Layer["External Integration Layer"]
+
+    DeepFace_Public_API -- "Delegates to" --> Facial_Analysis_Engine
+
+    DeepFace_Public_API -- "Delegates to" --> Model_Management_System
+
+    Model_Management_System -- "Provides models to" --> Facial_Analysis_Engine
+
+    Model_Management_System -- "Uses" --> Utility_Infrastructure_Layer
+
+    Facial_Analysis_Engine -- "Requests models from" --> Model_Management_System
+
+    Facial_Analysis_Engine -- "Uses" --> Utility_Infrastructure_Layer
+
+    Utility_Infrastructure_Layer -- "Supports" --> DeepFace_Public_API
+
+    Utility_Infrastructure_Layer -- "Supports" --> Model_Management_System
+
+    Utility_Infrastructure_Layer -- "Supports" --> Facial_Analysis_Engine
+
+    Utility_Infrastructure_Layer -- "Supports" --> External_Integration_Layer
+
+    External_Integration_Layer -- "Invokes" --> DeepFace_Public_API
+
+    External_Integration_Layer -- "Uses" --> Utility_Infrastructure_Layer
+
+    click Model_Management_System href "https://github.com/serengil/deepface/blob/main/.codeboarding//Model_Management_System.md" "Details"
+
+    click Facial_Analysis_Engine href "https://github.com/serengil/deepface/blob/main/.codeboarding//Facial_Analysis_Engine.md" "Details"
+
+    click Utility_Infrastructure_Layer href "https://github.com/serengil/deepface/blob/main/.codeboarding//Utility_Infrastructure_Layer.md" "Details"
+
+    click External_Integration_Layer href "https://github.com/serengil/deepface/blob/main/.codeboarding//External_Integration_Layer.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+Final Architecture Analysis for `deepface`
+
+
+
+Based on the Control Flow Graph (CFG) and Source Code analysis, the `deepface` project's architecture can be effectively summarized into five fundamental components. These components are chosen for their distinct responsibilities, high cohesion, and critical roles in the overall system's operation.
+
+
+
+Why these components are fundamental:
+
+
+
+These five components represent a clear and logical separation of concerns within the `deepface` project, making the architecture modular, maintainable, and scalable.
+
+
+
+1.  **DeepFace Public API**: This is fundamental because it defines the user experience and the primary interaction model with the library. It abstracts internal complexities, providing a clean and stable interface for developers.
+
+2.  **Model Management System**: DeepFace is built upon deep learning models. This component is absolutely critical for handling the acquisition, loading, and efficient management of these models, which are the core intellectual property and functional backbone of the library. Without it, every analysis task would need to manage its own model lifecycle.
+
+3.  **Facial Analysis Engine**: This is the "brain" of DeepFace, where all the specialized algorithms for face detection, recognition, and attribute analysis reside. It's fundamental because it encapsulates the core domain logic and the complex computational tasks that define the library's purpose.
+
+4.  **Utility & Infrastructure Layer**: This component provides essential cross-cutting services that are required by almost every other part of the system (e.g., logging, image handling). It's fundamental for ensuring consistency, reducing code duplication, and providing a robust foundation for the entire application.
+
+5.  **External Integration Layer**: This component is crucial for the broader applicability and deployability of DeepFace. By providing a REST API and streaming capabilities, it allows the library to be consumed by various applications and systems beyond direct Python scripting, making it a versatile and production-ready solution.
+
+
+
+Together, these components form a cohesive and well-structured architecture that effectively manages the complexities of deep learning-based facial analysis, from model management to user interaction and external integration.
+
+
+
+### DeepFace Public API
+
+This component serves as the primary public interface and orchestration layer for the entire DeepFace library. It provides high-level, user-friendly functions (`verify`, `analyze`, `represent`, `find`, `stream`, `extract_faces`, `build_model`) that abstract the underlying complexities of facial analysis. It acts as a facade, delegating tasks to specialized internal modules and ensuring a clean, consistent API for consumers.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/DeepFace.py#L1-L1000" target="_blank" rel="noopener noreferrer">`deepface.DeepFace` (1:1000)</a>
+
+
+
+
+
+### Model Management System
+
+This component is responsible for the lifecycle management of all deep learning models used by DeepFace. This includes dynamic loading, building, caching, and ensuring that pre-trained model weights are correctly downloaded and utilized. It abstracts the complexities of various model backends (e.g., TensorFlow, Keras) and provides a unified interface for accessing different types of models (facial recognition, detection, demography, anti-spoofing).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/modules/modeling.py#L1-L1000" target="_blank" rel="noopener noreferrer">`deepface.modules.modeling` (1:1000)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/commons/weight_utils.py#L1-L1000" target="_blank" rel="noopener noreferrer">`deepface.commons.weight_utils` (1:1000)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/models/Demography.py#L15-L67" target="_blank" rel="noopener noreferrer">`deepface.models.Demography` (15:67)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/models/Detector.py#L9-L27" target="_blank" rel="noopener noreferrer">`deepface.models.Detector` (9:27)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/models/FacialRecognition.py#L15-L47" target="_blank" rel="noopener noreferrer">`deepface.models.FacialRecognition` (15:47)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/models/spoofing/FasNet.py#L1-L1000" target="_blank" rel="noopener noreferrer">`deepface.models.spoofing.FasNet` (1:1000)</a>
+
+
+
+
+
+### Facial Analysis Engine
+
+This is the algorithmic core of DeepFace, containing the specialized modules that perform the actual facial analysis tasks. Each module within this component handles a specific aspect: face detection, facial representation (embedding generation), identity verification, identity recognition, demographic attribute prediction (age, gender, emotion, race), and image preprocessing (alignment, normalization). It encapsulates the complex machine learning logic.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/modules/detection.py#L1-L1000" target="_blank" rel="noopener noreferrer">`deepface.modules.detection` (1:1000)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/modules/representation.py#L1-L1000" target="_blank" rel="noopener noreferrer">`deepface.modules.representation` (1:1000)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/modules/verification.py#L1-L1000" target="_blank" rel="noopener noreferrer">`deepface.modules.verification` (1:1000)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/modules/recognition.py#L1-L1000" target="_blank" rel="noopener noreferrer">`deepface.modules.recognition` (1:1000)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/modules/demography.py#L1-L1000" target="_blank" rel="noopener noreferrer">`deepface.modules.demography` (1:1000)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/modules/preprocessing.py#L1-L1000" target="_blank" rel="noopener noreferrer">`deepface.modules.preprocessing` (1:1000)</a>
+
+
+
+
+
+### Utility & Infrastructure Layer
+
+This foundational component provides essential helper functions and cross-cutting concerns used throughout the entire DeepFace library. It includes utilities for image loading and manipulation, centralized logging, file system operations, package-related utilities, and constants. It ensures consistency and efficiency for common, non-domain-specific tasks.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/commons/image_utils.py#L1-L1000" target="_blank" rel="noopener noreferrer">`deepface.commons.image_utils` (1:1000)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/commons/logger.py#L1-L1000" target="_blank" rel="noopener noreferrer">`deepface.commons.logger` (1:1000)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/commons/folder_utils.py#L1-L1000" target="_blank" rel="noopener noreferrer">`deepface.commons.folder_utils` (1:1000)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/commons/package_utils.py#L1-L1000" target="_blank" rel="noopener noreferrer">`deepface.commons.package_utils` (1:1000)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/commons/constant.py#L1-L1000" target="_blank" rel="noopener noreferrer">`deepface.commons.constant` (1:1000)</a>
+
+
+
+
+
+### External Integration Layer
+
+This component is responsible for exposing DeepFace functionalities to external systems and handling specific interaction patterns beyond direct Python function calls. It primarily includes the REST API, which defines endpoints, parses incoming HTTP requests, and formats responses, and the streaming module, which manages real-time facial analysis from video feeds. It acts as the bridge for integrating DeepFace into web applications or live video processing pipelines.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/api/src/api.py#L1-L1000" target="_blank" rel="noopener noreferrer">`deepface.api.src.api` (1:1000)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/api/src/app.py#L1-L1000" target="_blank" rel="noopener noreferrer">`deepface.api.src.app` (1:1000)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/api/src/modules/core/routes.py#L1-L1000" target="_blank" rel="noopener noreferrer">`deepface.api.src.modules.core.routes` (1:1000)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/api/src/modules/core/service.py#L1-L1000" target="_blank" rel="noopener noreferrer">`deepface.api.src.modules.core.service` (1:1000)</a>
+
+- <a href="https://github.com/serengil/deepface/blob/master/deepface/modules/streaming.py#L1-L1000" target="_blank" rel="noopener noreferrer">`deepface.modules.streaming` (1:1000)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
## Tickets

### What has been done

With this PR, I intorduce high-level diagrams of the deepface codebase to help new contributors orient themselves in the codebase.
You can see how the proposed changes render here:
https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/deepface/on_boarding.md

I can see that the deepface has over 2.5K forks. That means that a lot of people are playing around with the codebase. We believe that most of them are interested in changes in just one component of the codebase. This is why we believe diagram first documentation is the way to go, as a person can immediately recognize and navigate to the component of interest. Futher now when they edit it, they have the bigger picture of how this component interacts with the rest of the codebase. Let me know what is your opinion on diagram first documentation!

I'd usually open a discussion first, but you don't have them enabled for this repo so I decided to go ahead and open a PR.

Any feedback is more than welcome!

Full transparency: we’re exploring this idea as a potential startup, but we’re still early and figuring out what’s actually useful to developers.

## How to test

Not relevant

```shell
make lint && make test
```