### PR TITLE
is_valid_landmark in test_landmark_sanitization file

### DIFF
--- a/deepface/modules/detection.py
+++ b/deepface/modules/detection.py
@@ -17,6 +17,23 @@ logger = Logger()
 
 # pylint: disable=no-else-raise
 
+def is_valid_landmark(coord: Optional[Union[tuple, list]], width: int, height: int) -> bool:
+    """
+    Check if a landmark coordinate is within valid image bounds.
+
+    Args:
+        coord (tuple or list or None): (x, y) coordinate to check.
+        width (int): Image width.
+        height (int): Image height.
+    Returns:
+        bool: True if coordinate is valid and within bounds, False otherwise.
+    """
+    if coord is None:
+        return False
+    if not (isinstance(coord, (tuple, list)) and len(coord) == 2):
+        return False
+    x, y = coord
+    return 0 <= x < width and 0 <= y < height
 
 def extract_faces(
     img_path: Union[str, np.ndarray, IO[bytes]],
@@ -90,22 +107,6 @@ def extract_faces(
 
     height, width, _ = img.shape
 
-    def is_valid_landmark(coord: Optional[Union[tuple, list]]) -> bool:
-        """
-        Check if a landmark coordinate is within valid image bounds.
-
-        Args:
-            coord (tuple or list or None): (x, y) coordinate to check.
-        Returns:
-            bool: True if coordinate is valid and within bounds, False otherwise.
-        """
-        if coord is None:
-            return False
-        if not (isinstance(coord, (tuple, list)) and len(coord) == 2):
-            return False
-        x, y = coord
-        return 0 <= x < width and 0 <= y < height
-
     base_region = FacialAreaRegion(x=0, y=0, w=width, h=height, confidence=0)
 
     if detector_backend == "skip":
@@ -175,7 +176,7 @@ def extract_faces(
 
         # Sanitize landmarks - set invalid ones to None
         for key, value in landmarks.items():
-            if not is_valid_landmark(value):
+            if not is_valid_landmark(value, width, height):
                 landmarks[key] = None
 
 

--- a/tests/test_landmark_sanitization.py
+++ b/tests/test_landmark_sanitization.py
@@ -1,17 +1,9 @@
 import numpy as np
 import pytest
-from deepface.modules.detection import extract_faces, DetectedFace, FacialAreaRegion
+from deepface.modules.detection import extract_faces, DetectedFace, FacialAreaRegion, is_valid_landmark
 from deepface.commons.logger import Logger
 
 logger = Logger()
-
-def is_valid_landmark(coord, width, height):
-    if coord is None:
-        return False
-    if not (isinstance(coord, (tuple, list)) and len(coord) == 2):
-        return False
-    x, y = coord
-    return 0 <= x < width and 0 <= y < height
 
 def sanitize_landmarks(region, width, height):
     landmarks = {


### PR DESCRIPTION
### What has been done

In `deepface/modules/detection.py`:
`is_valid_landmark` is now a top-level function (not a closure).
It takes `coord`, `width`, and `height` as arguments.
`extract_faces`  now use `is_valid_landmark(value, width, height)`.

In `tests/test_landmark_sanitization.py`:
The test now imports `is_valid_landmark` from `deepface.modules.detection`.
The local definition of `is_valid_landmark` was removed.
The test uses the real production logic for landmark validation, as you asked.
