### PR TITLE
Fix FastMtCnn detection error

### DIFF
--- a/deepface/models/face_detection/FastMtCnn.py
+++ b/deepface/models/face_detection/FastMtCnn.py
@@ -30,6 +30,7 @@ class FastMtCnnClient(Detector):
         resp = []
 
         img_rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)  # mtcnn expects RGB but OpenCV read BGR
+        img_rgb = img_rgb.astype("uint8") # Fix facenet-pytorch dtype
         detections = self.model.detect(
             img_rgb, landmarks=True
         )  # returns boundingbox, prob, landmark


### PR DESCRIPTION
### What has been done
Calling FastMtCnn detection throws an error due to facenet-pytorch only accepting uint8. This PR adds an explicit cast before calling the model to fix that error.

## How to test
* Install dependencies required for FastMtCnn
* Run FastMtCnn detection