### PR TITLE
Revert flask and werkzeug dependency changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,7 @@ Pillow>=5.2.0
 opencv-python>=4.5.5.64
 tensorflow>=1.9.0
 keras>=2.2.0
-Flask>=1.1.2,<=2.0.2
-werkzeug<=2.0.2
+Flask>=1.1.2
 flask_cors>=4.0.1
 mtcnn>=0.1.0
 retina-face>=0.0.14


### PR DESCRIPTION
chore: ⏪️ Revert flask and werkzeug dependency changes
Reverts changes from 5e90be91009eae73be0181e705c5d2f008832fce

## Tickets

https://github.com/serengil/deepface/issues/1501

### What has been done

Revert flask and werkzeug dependency version changes