### PR TITLE
replace training.Model with Model in ArcFace

### DIFF
--- a/deepface/models/facial_recognition/ArcFace.py
+++ b/deepface/models/facial_recognition/ArcFace.py
@@ -15,7 +15,6 @@ tf_version = package_utils.get_tf_major_version()
 
 if tf_version == 1:
     from keras.models import Model
-    from keras.engine import training
     from keras.layers import (
         ZeroPadding2D,
         Input,
@@ -29,7 +28,6 @@ if tf_version == 1:
     )
 else:
     from tensorflow.keras.models import Model
-    from tensorflow.python.keras.engine import training
     from tensorflow.keras.layers import (
         ZeroPadding2D,
         Input,
@@ -106,7 +104,7 @@ def ResNet34() -> Model:
     x = PReLU(shared_axes=[1, 2], name="conv1_prelu")(x)
     x = stack_fn(x)
 
-    model = training.Model(img_input, x, name="ResNet34")
+    model = Model(img_input, x, name="ResNet34")
 
     return model
 


### PR DESCRIPTION
[BUG]: Getting AttributeError: 'KerasHistory' object has no attribute 'layer' when calling DeepFace.represent with detector_backend="retinaface"

## Tickets

Resolves https://github.com/serengil/deepface/issues/1506

### What has been done

**from tensorflow.python.keras.engine import training
model = training.Model(img_input, x, name="ResNet34")**

TensorFlow considers anything under tensorflow.python.* a private/internal API. These APIs are not guaranteed to remain stable and may be blocked or unreliable—even if the file exists.

The public, stable interface is tf.keras.models.Model (or similarly, keras.models.Model in standalone Keras)
which is fully supported across all TensorFlow versions (1.x via standalone Keras, and 2.x via tf.keras)

now its should be updated as

**model = Model(img_input, x, name="ResNet34")
and should remove imports
from keras.engine import training
from tensorflow.python.keras.engine import training**

