### PR TITLE
Expose AVAILABLE_MODELS from build_model.

### DIFF
--- a/deepface/modules/modeling.py
+++ b/deepface/modules/modeling.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 # built-in dependencies
-from typing import Any
+from typing import TYPE_CHECKING, Any, Final, TypedDict
 
 # project dependencies
 from deepface.models.facial_recognition import (
@@ -12,7 +14,7 @@ from deepface.models.facial_recognition import (
     Dlib,
     Facenet,
     GhostFaceNet,
-    Buffalo_L
+    Buffalo_L,
 )
 from deepface.models.face_detection import (
     FastMtCnn,
@@ -28,6 +30,59 @@ from deepface.models.face_detection import (
 )
 from deepface.models.demography import Age, Gender, Race, Emotion
 from deepface.models.spoofing import FasNet
+
+if TYPE_CHECKING:
+    from deepface.models.Demography import Demography
+    from deepface.models.Detector import Detector
+    from deepface.models.FacialRecognition import FacialRecognition
+
+
+class AvailableModels(TypedDict):
+    facial_recognition: dict[str, type[FacialRecognition]]
+    spoofing: dict[str, type[FasNet.Fasnet]]
+    facial_attribute: dict[str, type[Demography]]
+    face_detector: dict[str, type[Detector]]
+
+
+AVAILABLE_MODELS: Final[AvailableModels] = {
+    "facial_recognition": {
+        "VGG-Face": VGGFace.VggFaceClient,
+        "OpenFace": OpenFace.OpenFaceClient,
+        "Facenet": Facenet.FaceNet128dClient,
+        "Facenet512": Facenet.FaceNet512dClient,
+        "DeepFace": FbDeepFace.DeepFaceClient,
+        "DeepID": DeepID.DeepIdClient,
+        "Dlib": Dlib.DlibClient,
+        "ArcFace": ArcFace.ArcFaceClient,
+        "SFace": SFace.SFaceClient,
+        "GhostFaceNet": GhostFaceNet.GhostFaceNetClient,
+        "Buffalo_L": Buffalo_L.Buffalo_L,
+    },
+    "spoofing": {
+        "Fasnet": FasNet.Fasnet,
+    },
+    "facial_attribute": {
+        "Emotion": Emotion.EmotionClient,
+        "Age": Age.ApparentAgeClient,
+        "Gender": Gender.GenderClient,
+        "Race": Race.RaceClient,
+    },
+    "face_detector": {
+        "opencv": OpenCv.OpenCvClient,
+        "mtcnn": MtCnn.MtCnnClient,
+        "ssd": Ssd.SsdClient,
+        "dlib": DlibDetector.DlibClient,
+        "retinaface": RetinaFace.RetinaFaceClient,
+        "mediapipe": MediaPipe.MediaPipeClient,
+        "yolov8": YoloFaceDetector.YoloDetectorClientV8n,
+        "yolov11n": YoloFaceDetector.YoloDetectorClientV11n,
+        "yolov11s": YoloFaceDetector.YoloDetectorClientV11s,
+        "yolov11m": YoloFaceDetector.YoloDetectorClientV11m,
+        "yunet": YuNet.YuNetClient,
+        "fastmtcnn": FastMtCnn.FastMtCnnClient,
+        "centerface": CenterFace.CenterFaceClient,
+    },
+}
 
 
 def build_model(task: str, model_name: str) -> Any:
@@ -49,54 +104,14 @@ def build_model(task: str, model_name: str) -> Any:
     # singleton design pattern
     global cached_models
 
-    models = {
-        "facial_recognition": {
-            "VGG-Face": VGGFace.VggFaceClient,
-            "OpenFace": OpenFace.OpenFaceClient,
-            "Facenet": Facenet.FaceNet128dClient,
-            "Facenet512": Facenet.FaceNet512dClient,
-            "DeepFace": FbDeepFace.DeepFaceClient,
-            "DeepID": DeepID.DeepIdClient,
-            "Dlib": Dlib.DlibClient,
-            "ArcFace": ArcFace.ArcFaceClient,
-            "SFace": SFace.SFaceClient,
-            "GhostFaceNet": GhostFaceNet.GhostFaceNetClient,
-            "Buffalo_L": Buffalo_L.Buffalo_L
-        },
-        "spoofing": {
-            "Fasnet": FasNet.Fasnet,
-        },
-        "facial_attribute": {
-            "Emotion": Emotion.EmotionClient,
-            "Age": Age.ApparentAgeClient,
-            "Gender": Gender.GenderClient,
-            "Race": Race.RaceClient,
-        },
-        "face_detector": {
-            "opencv": OpenCv.OpenCvClient,
-            "mtcnn": MtCnn.MtCnnClient,
-            "ssd": Ssd.SsdClient,
-            "dlib": DlibDetector.DlibClient,
-            "retinaface": RetinaFace.RetinaFaceClient,
-            "mediapipe": MediaPipe.MediaPipeClient,
-            "yolov8": YoloFaceDetector.YoloDetectorClientV8n,
-            "yolov11n": YoloFaceDetector.YoloDetectorClientV11n,
-            "yolov11s": YoloFaceDetector.YoloDetectorClientV11s,
-            "yolov11m": YoloFaceDetector.YoloDetectorClientV11m,
-            "yunet": YuNet.YuNetClient,
-            "fastmtcnn": FastMtCnn.FastMtCnnClient,
-            "centerface": CenterFace.CenterFaceClient,
-        },
-    }
-
-    if models.get(task) is None:
+    if task not in AVAILABLE_MODELS.keys():
         raise ValueError(f"unimplemented task - {task}")
 
-    if not "cached_models" in globals():
-        cached_models = {current_task: {} for current_task in models.keys()}
+    if "cached_models" not in globals():
+        cached_models = {current_task: {} for current_task in AVAILABLE_MODELS.keys()}
 
     if cached_models[task].get(model_name) is None:
-        model = models[task].get(model_name)
+        model = AVAILABLE_MODELS[task].get(model_name)
         if model:
             cached_models[task][model_name] = model()
         else:


### PR DESCRIPTION
## Tickets

### What has been done

This PR moves the dict containing available models from a local variable in `build_model` to a global variable `AVAILABLE_MODELS`.
This allows users of this package to query the available models using the new global dict.
I used a `TypedDict` to improve the type hints for this dict.

### What is this useful for?
For CLI options, e.g., using click, this PR allows to directly use the `AVAILABLE_MODELS` as a single source of truth.
The keys of this dict can be passed to `click.Choice` to automatically have all available models in the help text and to validate user input.
https://click.palletsprojects.com/en/stable/api/#click.Choice
```python
from __future__ import annotations

from typing import Annotated

import typer
import click
from deepface.modules.modeling import AVAILABLE_MODELS


def analyse(
    *,
    model: Annotated[
        str,
        typer.Option(
            click_type=click.Choice(
                choices=AVAILABLE_MODELS["facial_recognition"].keys(),
            ),
        ),
    ],
) -> None:
    print(model)


def main() -> None:
    app = typer.Typer()
    app.command()(analyse)
    app()


if __name__ == "__main__":
    main()

```

```bash
$ python snippet.py 
Usage: snippet.py [OPTIONS]
Try 'snippet.py --help' for help.
╭─ Error ───────────────────────────────────────────────────────────────────────────────────────╮
│ Missing option '--model' (env var: 'None'). Choose from:                                      │
│         VGG-Face,                                                                             │
│         OpenFace,                                                                             │
│         Facenet,                                                                              │
│         Facenet512,                                                                           │
│         DeepFace,                                                                             │
│         DeepID,                                                                               │
│         Dlib,                                                                                 │
│         ArcFace,                                                                              │
│         SFace,                                                                                │
│         GhostFaceNet,                                                                         │
│         Buffalo_L                                                                             │
╰───────────────────────────────────────────────────────────────────────────────────────────────╯

$ python snippet.py --model DeepFace2
Usage: snippet.py [OPTIONS]
Try 'snippet.py --help' for help.
╭─ Error ───────────────────────────────────────────────────────────────────────────────────────╮
│ Invalid value for '--model' (env var: 'None'): 'DeepFace2' is not one of 'VGG-Face',          │
│ 'OpenFace', 'Facenet', 'Facenet512', 'DeepFace', 'DeepID', 'Dlib', 'ArcFace', 'SFace',        │
│ 'GhostFaceNet', 'Buffalo_L'.                                                                  │
╰───────────────────────────────────────────────────────────────────────────────────────────────╯

$ python snippet.py --model DeepFace
DeepFace


```

## How to test

```shell
make lint && make test
```