### PR TITLE
output normalization functionalities added to represent

### DIFF
--- a/deepface/DeepFace.py
+++ b/deepface/DeepFace.py
@@ -396,6 +396,8 @@ def represent(
     normalization: str = "base",
     anti_spoofing: bool = False,
     max_faces: Optional[int] = None,
+    l2_normalize: bool = False,
+    minmax_normalize: bool = False,
 ) -> Union[List[Dict[str, Any]], List[List[Dict[str, Any]]]]:
     """
     Represent facial images as multi-dimensional vector embeddings.
@@ -433,6 +435,12 @@ def represent(
 
         max_faces (int): Set a limit on the number of faces to be processed (default is None).
 
+        l2_normalize (bool): Flag to enable L2 normalization (unit vector normalization)
+            of the output embeddings
+
+        minmax_normalize (bool): Flag to enable min-max normalization of the output embeddings
+            to the range [0, 1].
+
     Returns:
         results (List[Dict[str, Any]] or List[Dict[str, Any]]): A list of dictionaries.
             Result type becomes List of List of Dict if batch input passed.
@@ -460,6 +468,8 @@ def represent(
         normalization=normalization,
         anti_spoofing=anti_spoofing,
         max_faces=max_faces,
+        l2_normalize=l2_normalize,
+        minmax_normalize=minmax_normalize,
     )
 
 

--- a/deepface/config/minmax.py
+++ b/deepface/config/minmax.py
@@ -1,0 +1,19 @@
+from typing import Tuple
+
+# these values are determined empirically for each model from unit test items
+minmax_values = {
+    "VGG-Face": (0.0, 0.27054874177488775),
+    "Facenet": (-3.541942596435547, 3.247769594192505),
+    "Facenet512": (-4.388302803039551, 3.643190622329712),
+    "OpenFace": (-0.34191709756851196, 0.26318004727363586),
+    "DeepFace": (0.0, 17.294939041137695),
+    "DeepID": (0.0, 127.86836242675781),
+    "Dlib": (-0.41398656368255615, 0.5201137661933899),
+    "ArcFace": (-2.945136308670044, 2.087090015411377),
+}
+
+
+def get_minmax_values(model_name: str) -> Tuple[float, float]:
+    if model_name not in minmax_values:
+        return (0, 0)
+    return minmax_values[model_name]

--- a/deepface/modules/normalization.py
+++ b/deepface/modules/normalization.py
@@ -1,0 +1,93 @@
+# built-in dependencies
+from typing import List, Union, cast
+
+# third-party dependencies
+import numpy as np
+
+# project dependencies
+from deepface.config.minmax import get_minmax_values
+
+
+def is_flat_embedding(x: Union[List[float], List[List[float]]]) -> bool:
+    """
+    Check if the embeddings represent a single flat list of floats
+        rather than a list of list of float.
+    Args:
+        x (List[float] or List[List[float]]): Embeddings to check.
+    Returns:
+        bool: True if x is a flat list of floats, False otherwise.
+    """
+    return isinstance(x, list) and all(isinstance(i, (int, float)) for i in x)
+
+
+def normalize_embedding_minmax(
+    model_name: str, embeddings: Union[List[float], List[List[float]]]
+) -> Union[List[float], List[List[float]]]:
+    """
+    Normalize embeddings using min-max normalization based on model-specific min-max values.
+    Args:
+        model_name (str): Name of the model to get min-max values for.
+        embeddings (List[float] or List[List[float]]): Embeddings to normalize.
+    Returns:
+        List[float] or List[List[float]]: Normalized embeddings.
+    """
+    dim_min, dim_max = get_minmax_values(model_name)
+
+    if dim_max - dim_min == 0:
+        return embeddings
+
+    if is_flat_embedding(embeddings):
+        embeddings = cast(List[float], embeddings)  # let type checker know
+
+        # Clamp vals to [dim_min, dim_max] to ensure the norm-embedding stays in [0, 1]
+        embeddings = [max(x, dim_min) for x in embeddings]  # lower-bound clamp
+        embeddings = [min(x, dim_max) for x in embeddings]  # upper-bound clamp
+
+        embeddings = [(x - dim_min) / (dim_max - dim_min) for x in embeddings]
+
+    else:
+        normalized_embeddings = []
+        for emb in embeddings:
+            emb = cast(List[float], emb)  # let type checker know
+
+            # Clamp vals to [dim_min, dim_max] to ensure the norm-embedding stays in [0, 1]
+            emb = [max(x, dim_min) for x in emb]  # lower-bound clamp
+            emb = [min(x, dim_max) for x in emb]  # upper-bound clamp
+
+            emb = [(min(max(x, dim_min), dim_max) - dim_min) / (dim_max - dim_min) for x in emb]
+            normalized_embeddings.append(emb)
+        embeddings = normalized_embeddings
+
+    return embeddings
+
+
+def normalize_embedding_l2(
+    embeddings: Union[List[float], List[List[float]]],
+) -> Union[List[float], List[List[float]]]:
+    """
+    Normalize embeddings using L2 normalization.
+    Args:
+        embeddings (List[float] or List[List[float]]): Embeddings to normalize.
+    Returns:
+        List[float] or List[List[float]]: L2-normalized embeddings.
+    """
+    if is_flat_embedding(embeddings):
+        norm = np.linalg.norm(embeddings)
+        if norm > 0:
+            embeddings = cast(List[float], embeddings)  # let type checker know
+            norm = cast(float, norm)
+            embeddings = (np.array(embeddings) / norm).tolist()
+    else:
+        normalized_embeddings = []
+        for emb in embeddings:
+            emb = cast(List[float], emb)  # let type checker know
+            norm = np.linalg.norm(emb)
+            if norm > 0:
+                norm = cast(float, norm)
+                normalized_emb = (np.array(emb) / norm).tolist()
+            else:
+                normalized_emb = emb
+            normalized_embeddings.append(normalized_emb)
+        embeddings = normalized_embeddings
+
+    return embeddings

--- a/deepface/modules/representation.py
+++ b/deepface/modules/representation.py
@@ -9,6 +9,7 @@ import numpy as np
 from deepface.commons import image_utils
 from deepface.modules import modeling, detection, preprocessing
 from deepface.models.FacialRecognition import FacialRecognition
+from deepface.modules.normalization import normalize_embedding_l2, normalize_embedding_minmax
 
 
 def represent(
@@ -21,6 +22,8 @@ def represent(
     normalization: str = "base",
     anti_spoofing: bool = False,
     max_faces: Optional[int] = None,
+    l2_normalize: bool = False,
+    minmax_normalize: bool = False,
 ) -> Union[List[Dict[str, Any]], List[List[Dict[str, Any]]]]:
     """
     Represent facial images as multi-dimensional vector embeddings.
@@ -53,6 +56,12 @@ def represent(
         anti_spoofing (boolean): Flag to enable anti spoofing (default is False).
 
         max_faces (int): Set a limit on the number of faces to be processed (default is None).
+
+        l2_normalize (bool): Flag to enable L2 normalization (unit vector normalization)
+            of the output embeddings
+
+        minmax_normalize (bool): Flag to enable min-max normalization of the output embeddings
+            to the range [0, 1].
 
     Returns:
         results (List[Dict[str, Any]] or List[Dict[str, Any]]): A list of dictionaries.
@@ -162,6 +171,12 @@ def represent(
 
     # Forward pass through the model for the entire batch
     embeddings = model.forward(batch_images)
+
+    if minmax_normalize:
+        embeddings = normalize_embedding_minmax(model_name, embeddings)
+
+    if l2_normalize:
+        embeddings = normalize_embedding_l2(embeddings)
 
     resp_objs_dict = defaultdict(list)
     for idy, batch_index in enumerate(batch_indexes):

--- a/tests/test_output_normalization.py
+++ b/tests/test_output_normalization.py
@@ -1,0 +1,93 @@
+# 3rd-party dependencies
+import numpy as np
+
+# project dependencies
+from deepface import DeepFace
+from deepface.modules.normalization import normalize_embedding_minmax
+from deepface.config.minmax import minmax_values
+
+
+def test_minmax_normalization():
+    results = DeepFace.represent(
+        img_path="dataset/img1.jpg",
+        model_name="Facenet",
+        minmax_normalize=False,
+    )
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    for result in results:
+        embedding = result["embedding"]
+        assert any(x < 0.0 or x > 1.0 for x in embedding)  # not normalized
+
+    results = DeepFace.represent(
+        img_path="dataset/img1.jpg",
+        model_name="Facenet",
+        minmax_normalize=True,
+    )
+    for result in results:
+        embedding = result["embedding"]
+        assert all(x >= 0.0 and x <= 1.0 for x in embedding)  # normalized
+
+
+def test_minmax_normalization_batch():
+    results = DeepFace.represent(
+        img_path=["dataset/img1.jpg", "dataset/couple.jpg"],
+        model_name="Facenet",
+        minmax_normalize=True,
+    )
+    assert isinstance(results, list)
+    assert len(results) == 2
+    expected_embeddings = [1, 2]
+    for idx, current_results in enumerate(results):
+        assert isinstance(current_results, list)
+        assert len(current_results) == expected_embeddings[idx]
+        for result in current_results:
+            embedding = result["embedding"]
+            assert all(x >= 0.0 and x <= 1.0 for x in embedding)  # normalized
+
+
+def test_minmax_normalization_edge_values():
+    results = DeepFace.represent(
+        img_path="dataset/img1.jpg",
+        model_name="Facenet",
+        minmax_normalize=False,
+    )
+    for result in results:
+        embedding = result["embedding"]
+        dim_min, dim_max = minmax_values["Facenet"]
+
+        add_val = dim_max - max(embedding) + 0.2
+        sub_val = abs(dim_min) - abs(min(embedding)) + 0.2
+
+        shifted_embedding = [x + add_val if x > 0 else x - sub_val for x in embedding]
+        normalized_embedding = normalize_embedding_minmax("Facenet", shifted_embedding)
+        assert any(x < 0.0 or x > 1.0 for x in shifted_embedding)  # not normalized
+        assert all(x >= 0.0 and x <= 1.0 for x in normalized_embedding)  # normalized
+
+
+def test_l2_normalization():
+    results = DeepFace.represent(
+        img_path="dataset/img1.jpg",
+        model_name="Facenet",
+        l2_normalize=False,
+    )
+    raw_embedding = results[0]["embedding"]
+    norm = np.linalg.norm(raw_embedding)
+    assert not np.isclose(norm, 1.0), f"L2 norm of norm embedding shouldn't be 1, got {norm}"
+
+    results = DeepFace.represent(
+        img_path="dataset/img1.jpg",
+        model_name="Facenet",
+        l2_normalize=True,
+    )
+    l2_embedding = results[0]["embedding"]
+
+    # L2 embedding != raw embedding
+    assert not np.allclose(
+        l2_embedding, raw_embedding
+    ), "L2 normalized embedding should differ from raw embedding"
+
+    # Norm of L2 embedding should be 1
+    norm = np.linalg.norm(l2_embedding)
+    assert np.isclose(norm, 1.0), f"L2 norm of normalized embedding should be 1, got {norm}"


### PR DESCRIPTION
## Tickets

-
### What has been done

With this PR, we will be able to do l2_normalization in represent function to get l2 normalized embeddings.

Besides, we added min-max normalization functionality to get the dimension values of output embedding in [0, 1] range - this will be important in PHE.

## How to test

```shell
make lint && make test
```