### PR TITLE
throw custom errors

### DIFF
--- a/deepface/commons/image_utils.py
+++ b/deepface/commons/image_utils.py
@@ -14,6 +14,9 @@ import cv2
 from PIL import Image
 from werkzeug.datastructures import FileStorage
 
+# project dependencies
+from deepface.modules.exceptions import ImgNotFound, DataTypeError
+
 
 IMAGE_EXTS = {".jpg", ".jpeg", ".png"}
 PIL_EXTS = {"jpeg", "png"}
@@ -97,14 +100,14 @@ def load_image(
     # The image is an object that supports `.read`
     if hasattr(img, "read") and callable(img.read):
         if isinstance(img, io.StringIO):
-            raise ValueError("img requires bytes and cannot be an io.StringIO object.")
+            raise DataTypeError("img requires bytes and cannot be an io.StringIO object.")
         return load_image_from_io_object(cast(IO[bytes], img)), "io object"
 
     if isinstance(img, Path):
         img = str(img)
 
     if not isinstance(img, str):
-        raise ValueError(f"img must be numpy array or str but it is {type(img)}")
+        raise DataTypeError(f"img must be numpy array or str but it is {type(img)}")
 
     # The image is a base64 string
     if img.startswith("data:image/"):
@@ -116,7 +119,7 @@ def load_image(
 
     # The image is a path
     if not os.path.isfile(img):
-        raise ValueError(f"Confirm that {img} exists")
+        raise ImgNotFound(f"Confirm that {img} exists")
 
     # image must be a file on the system then
 
@@ -177,7 +180,7 @@ def load_image_from_base64(uri: str) -> NDArray[Any]:
     with Image.open(io.BytesIO(decoded_bytes)) as img:
         file_type = img.format.lower()
         if file_type not in {"jpeg", "png"}:
-            raise ValueError(f"Input image can be jpg or png, but it is {file_type}")
+            raise DataTypeError(f"Input image can be jpg or png, but it is {file_type}")
 
     nparr = np.frombuffer(decoded_bytes, np.uint8)
     img_bgr = cv2.imdecode(nparr, cv2.IMREAD_COLOR)

--- a/deepface/commons/weight_utils.py
+++ b/deepface/commons/weight_utils.py
@@ -10,6 +10,7 @@ import gdown
 # project dependencies
 from deepface.commons import folder_utils, package_utils
 from deepface.commons.logger import Logger
+from deepface.modules.exceptions import UnimplementedError
 
 
 tf_version = package_utils.get_tf_major_version()
@@ -46,7 +47,7 @@ def download_weights_if_necessary(
         return target_file
 
     if compress_type is not None and compress_type not in ALLOWED_COMPRESS_TYPES:
-        raise ValueError(f"unimplemented compress type - {compress_type}")
+        raise UnimplementedError(f"unimplemented compress type - {compress_type}")
 
     try:
         logger.info(f"🔗 {file_name} will be downloaded from {source_url} to {target_file}...")
@@ -223,7 +224,7 @@ def download_all_models_in_one_shot() -> None:
             filename = i["filename"]
             url = i["url"]
         else:
-            raise ValueError("unimplemented scenario")
+            raise UnimplementedError("unimplemented scenario")
         logger.info(
             f"Downloading {url} to ~/.deepface/weights/{filename} with {compress_type} compression"
         )

--- a/deepface/models/FacialRecognition.py
+++ b/deepface/models/FacialRecognition.py
@@ -8,6 +8,7 @@ from numpy.typing import NDArray
 
 # project imports
 from deepface.commons import package_utils
+from deepface.modules.exceptions import InvalidEmbeddingsShapeError
 
 tf_version = package_utils.get_tf_major_version()
 if tf_version == 2:
@@ -43,7 +44,9 @@ class FacialRecognition(ABC):
         elif img.ndim == 4 and img.shape[0] > 1:
             embeddings = self.model.predict_on_batch(img)
         else:
-            raise ValueError(f"Input image must be (1, X, X, 3) shaped but it is {img.shape}")
+            raise InvalidEmbeddingsShapeError(
+                f"Input image must be (1, X, X, 3) shaped but it is {img.shape}"
+            )
 
         assert isinstance(
             embeddings, np.ndarray

--- a/deepface/models/face_detection/OpenCv.py
+++ b/deepface/models/face_detection/OpenCv.py
@@ -8,6 +8,7 @@ from numpy.typing import NDArray
 
 # project dependencies
 from deepface.models.Detector import Detector, FacialAreaRegion
+from deepface.modules.exceptions import UnimplementedError
 
 
 class OpenCvClient(Detector):
@@ -167,7 +168,7 @@ class OpenCvClient(Detector):
             detector = cv2.CascadeClassifier(eye_detector_path)
 
         else:
-            raise ValueError(f"unimplemented model_name for build_cascade - {model_name}")
+            raise UnimplementedError(f"unimplemented model_name for build_cascade - {model_name}")
 
         return detector
 

--- a/deepface/models/facial_recognition/Buffalo_L.py
+++ b/deepface/models/facial_recognition/Buffalo_L.py
@@ -10,6 +10,7 @@ from numpy.typing import NDArray
 from deepface.commons import weight_utils, folder_utils
 from deepface.commons.logger import Logger
 from deepface.models.FacialRecognition import FacialRecognition
+from deepface.modules.exceptions import InvalidEmbeddingsShapeError
 
 logger = Logger()
 
@@ -70,7 +71,9 @@ class Buffalo_L(FacialRecognition):
         if len(img.shape) == 3:
             img = np.expand_dims(img, axis=0)  # Convert single image to batch of 1
         elif len(img.shape) != 4:
-            raise ValueError(f"Input must be (112, 112, 3) or (X, 112, 112, 3). Got {img.shape}")
+            raise InvalidEmbeddingsShapeError(
+                f"Input must be (112, 112, 3) or (X, 112, 112, 3). Got {img.shape}"
+            )
         # Convert RGB to BGR for the entire batch
         img = img[:, :, :, ::-1]
         return img

--- a/deepface/modules/demography.py
+++ b/deepface/modules/demography.py
@@ -9,6 +9,7 @@ from tqdm import tqdm
 # project dependencies
 from deepface.modules import modeling, detection, preprocessing
 from deepface.models.demography import Gender, Race, Emotion
+from deepface.modules.exceptions import UnimplementedError, SpoofDetected
 
 
 # pylint: disable=too-many-positional-arguments
@@ -140,7 +141,7 @@ def analyze(
     # For each action, check if it is valid
     for action in actions:
         if action not in ("emotion", "age", "gender", "race"):
-            raise ValueError(
+            raise UnimplementedError(
                 f"Invalid action passed ({repr(action)})). "
                 "Valid actions are `emotion`, `age`, `gender`, `race`."
             )
@@ -162,7 +163,7 @@ def analyze(
 
     for img_obj in img_objs:
         if anti_spoofing is True and img_obj.get("is_real", True) is False:
-            raise ValueError("Spoof detected in the given image.")
+            raise SpoofDetected("Spoof detected in the given image.")
 
         img_content = img_obj["face"]
         img_region = img_obj["facial_area"]

--- a/deepface/modules/detection.py
+++ b/deepface/modules/detection.py
@@ -12,7 +12,8 @@ from deepface.modules import modeling
 from deepface.models.Detector import Detector, DetectedFace, FacialAreaRegion
 from deepface.commons import image_utils
 from deepface.models.face_detection import OpenCv
-
+from deepface.modules.exceptions import FaceNotDetected
+from deepface.modules.exceptions import UnimplementedError, ImgNotFound
 from deepface.commons.logger import Logger
 
 logger = Logger()
@@ -157,13 +158,13 @@ def extract_faces(
     # in case of no face found
     if len(face_objs) == 0 and enforce_detection is True:
         if img_name is not None:
-            raise ValueError(
+            raise FaceNotDetected(
                 f"Face could not be detected in {img_name}."
                 "Please confirm that the picture is a face photo "
                 "or consider to set enforce_detection param to False."
             )
         else:
-            raise ValueError(
+            raise FaceNotDetected(
                 "Face could not be detected. Please confirm that the picture is a face photo "
                 "or consider to set enforce_detection param to False."
             )
@@ -189,7 +190,9 @@ def extract_faces(
             elif color_face == "gray":
                 current_img = cv2.cvtColor(current_img, cv2.COLOR_BGR2GRAY)
             else:
-                raise ValueError(f"The color_face can be rgb, bgr or gray, but it is {color_face}.")
+                raise UnimplementedError(
+                    f"The color_face can be rgb, bgr or gray, but it is {color_face}."
+                )
 
         if normalize_face:
             current_img = current_img / 255  # normalize input in [0, 1]
@@ -250,7 +253,7 @@ def extract_faces(
         resp_objs.append(resp_obj)
 
     if len(resp_objs) == 0 and enforce_detection == True:
-        raise ValueError(
+        raise ImgNotFound(
             f"Exception while extracting faces from {img_name}."
             "Consider to set enforce_detection arg to False."
         )

--- a/deepface/modules/exceptions.py
+++ b/deepface/modules/exceptions.py
@@ -1,0 +1,55 @@
+# pylint: disable=unnecessary-pass
+
+
+class ImgNotFound(ValueError):
+    """Raised when the input image is not found or cannot be loaded."""
+
+    pass
+
+
+class PathNotFound(ValueError):
+    """Raised when the input path is not found."""
+
+    pass
+
+
+class FaceNotDetected(ValueError):
+    """Raised when no face is detected in the input image."""
+
+    pass
+
+
+class SpoofDetected(ValueError):
+    """Raised when a spoofed face is detected in the input image."""
+
+    pass
+
+
+class EmptyDatasource(ValueError):
+    """Raised when the provided data source is empty."""
+
+    pass
+
+
+class DimensionMismatchError(ValueError):
+    """Raised when the dimensions of the input do not match the expected dimensions."""
+
+    pass
+
+
+class InvalidEmbeddingsShapeError(ValueError):
+    """Raised when the shape of the embeddings is invalid."""
+
+    pass
+
+
+class DataTypeError(ValueError):
+    """Raised when the input data type is incorrect."""
+
+    pass
+
+
+class UnimplementedError(ValueError):
+    """Raised when a requested feature is not implemented."""
+
+    pass

--- a/deepface/modules/modeling.py
+++ b/deepface/modules/modeling.py
@@ -30,6 +30,7 @@ from deepface.models.face_detection import (
 )
 from deepface.models.demography import Age, Gender, Race, Emotion
 from deepface.models.spoofing import FasNet
+from deepface.modules.exceptions import UnimplementedError
 
 if TYPE_CHECKING:
     from deepface.models.Demography import Demography
@@ -114,7 +115,7 @@ def build_model(task: str, model_name: str) -> Any:
     global cached_models
 
     if task not in AVAILABLE_MODELS.keys():
-        raise ValueError(f"unimplemented task - {task}")
+        raise UnimplementedError(f"unimplemented task - {task}")
 
     if "cached_models" not in globals():
         cached_models = {current_task: {} for current_task in AVAILABLE_MODELS.keys()}
@@ -124,6 +125,6 @@ def build_model(task: str, model_name: str) -> Any:
         if model:
             cached_models[task][model_name] = model()
         else:
-            raise ValueError(f"Invalid model_name passed - {task}/{model_name}")
+            raise UnimplementedError(f"Invalid model_name passed - {task}/{model_name}")
 
     return cached_models[task][model_name]

--- a/deepface/modules/representation.py
+++ b/deepface/modules/representation.py
@@ -13,6 +13,7 @@ from deepface.modules import modeling, detection, preprocessing
 from deepface.models.FacialRecognition import FacialRecognition
 from deepface.modules.normalization import normalize_embedding_l2, normalize_embedding_minmax
 from deepface.modules.encryption import encrypt_embeddings
+from deepface.modules.exceptions import SpoofDetected
 from deepface.commons.logger import Logger
 
 logger = Logger()
@@ -160,7 +161,7 @@ def represent(
 
         for img_obj in img_objs:
             if anti_spoofing is True and img_obj.get("is_real", True) is False:
-                raise ValueError("Spoof detected in the given image.")
+                raise SpoofDetected("Spoof detected in the given image.")
 
             img = img_obj["face"]
 

--- a/deepface/modules/verification.py
+++ b/deepface/modules/verification.py
@@ -13,7 +13,12 @@ from deepface.models.FacialRecognition import FacialRecognition
 from deepface.commons.logger import Logger
 from deepface.config.confidence import confidences
 from deepface.config.threshold import thresholds
-
+from deepface.modules.exceptions import (
+    SpoofDetected,
+    DimensionMismatchError,
+    DataTypeError,
+    InvalidEmbeddingsShapeError,
+)
 
 logger = Logger()
 
@@ -155,7 +160,7 @@ def verify(
             # given image is already pre-calculated embedding
             if not all(isinstance(dim, (float, int)) for dim in img_path):
 
-                raise ValueError(
+                raise DataTypeError(
                     f"When passing img{index}_path as a list,"
                     " ensure that all its items are of type float."
                 )
@@ -168,7 +173,7 @@ def verify(
                 )
 
             if len(img_path) != dims:
-                raise ValueError(
+                raise DimensionMismatchError(
                     f"embeddings of {model_name} should have {dims} dimensions,"
                     f" but {index}-th image has {len(img_path)} dimensions input"
                 )
@@ -270,7 +275,7 @@ def __extract_faces_and_embeddings(
     # find embeddings for each face
     for img_obj in img_objs:
         if anti_spoofing is True and img_obj.get("is_real", True) is False:
-            raise ValueError("Spoof detected in given image.")
+            raise SpoofDetected("Spoof detected in given image.")
         img_embedding_obj = representation.represent(
             img_path=img_obj["face"][:, :, ::-1],  # make compatible with direct representation call
             model_name=model_name,
@@ -320,7 +325,7 @@ def find_cosine_distance(
         distances = 1 - cosine_similarities
         return cast(NDArray[Any], distances)
     else:
-        raise ValueError(
+        raise InvalidEmbeddingsShapeError(
             f"Embeddings must be 1D or 2D, but received "
             f"source shape: {source_representation.shape}, test shape: {test_representation.shape}"
         )


### PR DESCRIPTION
## Tickets

Resolves https://github.com/serengil/deepface/issues/1513

### What has been done

With this PR, we introduce custom exceptions that inherit from ValueError. This ensures backward compatibility for users who currently handle ValueError based on the exception message, while allowing new users to catch these custom exceptions explicitly.

## How to test

```shell
make lint && make test
```