### PR TITLE
sorting broken tests

### DIFF
--- a/deepface/api/postman/deepface-api.postman_collection.json
+++ b/deepface/api/postman/deepface-api.postman_collection.json
@@ -54,7 +54,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n  \"model_name\": \"Facenet\",\n  \"detector_backend\": \"mtcnn\",\n  \"img\": \"https://raw.githubusercontent.com/serengil/deepface/refs/heads/master/tests/dataset/img1.jpg\"\n}",
+					"raw": "{\n  \"model_name\": \"Facenet\",\n  \"detector_backend\": \"mtcnn\",\n  \"img\": \"https://raw.githubusercontent.com/serengil/deepface/refs/heads/master/tests/unit/dataset/img1.jpg\"\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -85,7 +85,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "  {\n  \t\"img1\": \"https://raw.githubusercontent.com/serengil/deepface/refs/heads/master/tests/dataset/img1.jpg\",\n    \"img2\": \"https://raw.githubusercontent.com/serengil/deepface/refs/heads/master/tests/dataset/img3.jpg\",\n    \"model_name\": \"Facenet\",\n    \"detector_backend\": \"opencv\",\n    \"distance_metric\": \"euclidean\"\n  }",
+					"raw": "  {\n  \t\"img1\": \"https://raw.githubusercontent.com/serengil/deepface/refs/heads/master/tests/unit/dataset/img1.jpg\",\n    \"img2\": \"https://raw.githubusercontent.com/serengil/deepface/refs/heads/master/tests/unit/dataset/img3.jpg\",\n    \"model_name\": \"Facenet\",\n    \"detector_backend\": \"opencv\",\n    \"distance_metric\": \"euclidean\"\n  }",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -163,7 +163,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"__img\": \"/Users/sefik/Desktop/deepface/tests/dataset/img2.jpg\",\n    \"img\": \"https://raw.githubusercontent.com/serengil/deepface/refs/heads/master/tests/dataset/img2.jpg\",\n    \"__actions\": [\"age\", \"gender\", \"emotion\", \"race\"],\n    \"actions\": [\"age\"]\n}",
+					"raw": "{\n    \"__img\": \"/Users/sefik/Desktop/deepface/tests/dataset/img2.jpg\",\n    \"img\": \"https://raw.githubusercontent.com/serengil/deepface/refs/heads/master/tests/unit/dataset/img2.jpg\",\n    \"__actions\": [\"age\", \"gender\", \"emotion\", \"race\"],\n    \"actions\": [\"age\"]\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -233,7 +233,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n  \"model_name\": \"Facenet\",\n  \"detector_backend\": \"mtcnn\",\n  \"align\": true,\n  \"l2_normalize\": true,\n  \"img\": \"https://raw.githubusercontent.com/serengil/deepface/refs/heads/master/tests/dataset/img18.jpg\"\n}",
+					"raw": "{\n  \"model_name\": \"Facenet\",\n  \"detector_backend\": \"mtcnn\",\n  \"align\": true,\n  \"l2_normalize\": true,\n  \"img\": \"https://raw.githubusercontent.com/serengil/deepface/refs/heads/master/tests/unit/dataset/img18.jpg\"\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -264,7 +264,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n  \"img\": \"https://raw.githubusercontent.com/serengil/deepface/refs/heads/master/tests/dataset/img1.jpg\",\n  \"model_name\": \"Facenet\",\n  \"detector_backend\": \"mtcnn\",\n  \"align\": true,\n  \"l2_normalize\": true,\n  \"distance_metric\": \"cosine\",\n  \"search_method\": \"exact\"\n}",
+					"raw": "{\n  \"img\": \"https://raw.githubusercontent.com/serengil/deepface/refs/heads/master/tests/unit/dataset/img1.jpg\",\n  \"model_name\": \"Facenet\",\n  \"detector_backend\": \"mtcnn\",\n  \"align\": true,\n  \"l2_normalize\": true,\n  \"distance_metric\": \"cosine\",\n  \"search_method\": \"exact\"\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -295,7 +295,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n  \"img\": \"https://raw.githubusercontent.com/serengil/deepface/refs/heads/master/tests/dataset/img1.jpg\",\n  \"model_name\": \"Facenet\",\n  \"detector_backend\": \"mtcnn\",\n  \"align\": true,\n  \"l2_normalize\": true,\n  \"search_method\": \"ann\"\n}",
+					"raw": "{\n  \"img\": \"https://raw.githubusercontent.com/serengil/deepface/refs/heads/master/tests/unit/dataset/img1.jpg\",\n  \"model_name\": \"Facenet\",\n  \"detector_backend\": \"mtcnn\",\n  \"align\": true,\n  \"l2_normalize\": true,\n  \"search_method\": \"ann\"\n}",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -24,12 +24,8 @@ from deepface.modules import detection
 
 logger = Logger()
 
-IMG1_SOURCE = (
-    "https://raw.githubusercontent.com/serengil/deepface/refs/heads/master/tests/dataset/img1.jpg"
-)
-IMG2_SOURCE = (
-    "https://raw.githubusercontent.com/serengil/deepface/refs/heads/master/tests/dataset/img2.jpg"
-)
+IMG1_SOURCE = "https://raw.githubusercontent.com/serengil/deepface/refs/heads/master/tests/unit/dataset/img1.jpg"
+IMG2_SOURCE = "https://raw.githubusercontent.com/serengil/deepface/refs/heads/master/tests/unit/dataset/img2.jpg"
 DUMMY_APP = Flask(__name__)
 
 
@@ -142,7 +138,7 @@ class TestVerifyEndpoint(unittest.TestCase):
         data = {
             "model_name": "Facenet",
             "detector_backend": "mtcnn",
-            "img": "https://github.com/serengil/deepface/blob/master/tests/dataset/couple.jpg?raw=true",
+            "img": "https://github.com/serengil/deepface/blob/master/tests/unit/dataset/couple.jpg?raw=true",
         }
 
         response = self.app.post("/represent", json=data)
@@ -193,7 +189,7 @@ class TestVerifyEndpoint(unittest.TestCase):
             # image path
             image_path,
             # image url
-            f"https://github.com/serengil/deepface/blob/master/tests/{image_path}?raw=true",
+            f"https://github.com/serengil/deepface/blob/master/tests/unit/{image_path}?raw=true",
             # encoded image
             encoded_image,
         ]
@@ -306,8 +302,8 @@ class TestVerifyEndpoint(unittest.TestCase):
                     "detector_backend": "mtcnn",
                 },
             )
-            assert response.status_code == 200
             result = response.json
+            assert response.status_code == 200, response.data
             assert isinstance(result, dict)
             assert result.get("age") is not True
             assert result.get("dominant_gender") is not True
@@ -330,7 +326,7 @@ class TestVerifyEndpoint(unittest.TestCase):
                         "distance_metric": "euclidean",
                     },
                 )
-                assert response.status_code == 200
+                assert response.status_code == 200, response.data
                 result = response.json
                 assert isinstance(result, dict)
                 assert result.get("verified") is not None


### PR DESCRIPTION
## Tickets

-

### What has been done

Once we merged stateless search PR, urls of unit tests items were changed. This causes failures unit tests using them with url. This PR fixes this issue.

## How to test

```shell
make lint && make test
```