### PR TITLE
load models on app start up to respond faster in 1st request

### DIFF
--- a/deepface/api/.env.example
+++ b/deepface/api/.env.example
@@ -1,1 +1,6 @@
+DEEPFACE_DATABASE_TYPE=postgres
 DEEPFACE_CONNECTION_DETAILS=
+
+# set models here with commas to load on app start up, otherwise they will load in the 1st request and respond slower
+DEEPFACE_FACE_RECOGNITION_MODELS=VGG-Face,Facenet
+DEEPFACE_FACE_DETECTION_MODELS=mtcnn

--- a/deepface/api/src/dependencies/variables.py
+++ b/deepface/api/src/dependencies/variables.py
@@ -5,5 +5,7 @@ import os
 # pylint: disable=too-few-public-methods
 class Variables:
     def __init__(self) -> None:
-        self.database_type = os.getenv("DATABASE_TYPE", "postgres").lower()
+        self.database_type = os.getenv("DEEPFACE_DATABASE_TYPE", "postgres").lower()
         self.conection_details = os.getenv("DEEPFACE_CONNECTION_DETAILS")
+        self.face_recognition_models = os.getenv("DEEPFACE_FACE_RECOGNITION_MODELS")
+        self.face_detection_models = os.getenv("DEEPFACE_FACE_DETECTION_MODELS")


### PR DESCRIPTION
## Tickets

Resolves https://github.com/serengil/deepface/issues/1547

### What has been done

With this PR,  we will load models given in env vars on app start up to respond faster in 1st request.

Models were loaded in 1st request and it takes some time because they are complex models. We were able to respond faster from 2nd request. Now, we will load them on app start up if they are given in `DEEPFACE_FACE_RECOGNITION_MODELS` and `DEEPFACE_FACE_DETECTION_MODELS` as comma seperated.

## How to test

```shell
make lint && make test
```