### PR TITLE
return img_name for faiss searches

### DIFF
--- a/deepface/DeepFace.py
+++ b/deepface/DeepFace.py
@@ -850,6 +850,13 @@ def search(
             - aligned: Whether face alignment was performed.
             - l2_normalized: Whether L2 normalization was applied.
             - search_method: Method used for searching identities: exact or ann.
+            - confidence: Confidence score indicating the likelihood that the images
+                represent the same person. The score is between 0 and 100, where higher values
+                indicate greater confidence in the verification result.
+            - target_x, target_y, target_w, target_h: Bounding box coordinates of the
+                target face in the database. Notice that source image's face coordinates
+                are not included in the result here.
+            - threshold: threshold to determine a pair whether same person or different persons
             - distance_metric: Distance metric used for similarity measurement.
                 Distance metric will be ignored for ann search, and set to cosine if l2_normalize
                 is True, euclidean if l2_normalize is False.

--- a/deepface/modules/database/mongo.py
+++ b/deepface/modules/database/mongo.py
@@ -266,7 +266,7 @@ class MongoDbClient(Database):
         for doc in cursor:
             results.append(
                 {
-                    # "_id": str(doc["_id"]),
+                    "_id": str(doc["_id"]),
                     "id": doc["sequence"],
                     "img_name": doc["img_name"],
                     "embedding": doc["embedding"],
@@ -292,3 +292,31 @@ class MongoDbClient(Database):
         ANN search using the main vector (embedding).
         """
         raise NotImplementedError("ANN search is not natively supported in MongoDB.")
+
+    def search_by_id(
+        self,
+        ids: Union[List[str], List[int]],
+    ) -> List[Dict[str, Any]]:
+        """
+        Search records by their IDs.
+        """
+        cursor = self.embeddings.find(
+            {"sequence": {"$in": ids}},
+            {
+                "_id": 1,
+                "sequence": 1,
+                "img_name": 1,
+            },
+        )
+
+        results: List[Dict[str, Any]] = []
+        for doc in cursor:
+            results.append(
+                {
+                    "_id": str(doc["_id"]),
+                    "id": doc["sequence"],
+                    "img_name": doc["img_name"],
+                }
+            )
+
+        return results

--- a/deepface/modules/database/postgres.py
+++ b/deepface/modules/database/postgres.py
@@ -312,3 +312,36 @@ class PostgresClient(Database):
         ANN search using the main vector (embedding).
         """
         raise NotImplementedError("ANN search is not natively supported in Postgres.")
+
+    def search_by_id(
+        self,
+        ids: Union[List[str], List[int]],
+    ) -> List[Dict[str, Any]]:
+        """
+        Search records by their IDs.
+        """
+        if not ids:
+            return []
+
+        # we may return the face in the future
+        query = """
+            SELECT id, img_name
+            FROM embeddings
+            WHERE id = ANY(%s)
+            ORDER BY id ASC;
+        """
+
+        results: List[Dict[str, Any]] = []
+
+        with self.conn.cursor() as cur:
+            cur.execute(query, (ids,))
+            rows = cur.fetchall()
+            for r in rows:
+                results.append(
+                    {
+                        "id": r[0],
+                        "img_name": r[1],
+                    }
+                )
+
+        return results

--- a/deepface/modules/database/types.py
+++ b/deepface/modules/database/types.py
@@ -1,5 +1,5 @@
 # built-in dependencies
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 from abc import ABC, abstractmethod
 
 
@@ -79,5 +79,15 @@ class Database(ABC):
     ) -> List[Dict[str, Any]]:
         """
         ANN search using the main vector (embedding).
+        """
+        pass
+
+    @abstractmethod
+    def search_by_id(
+        self,
+        ids: Union[List[str], List[int]],
+    ) -> List[Dict[str, Any]]:
+        """
+        Search records by their IDs.
         """
         pass

--- a/deepface/modules/database/weaviate.py
+++ b/deepface/modules/database/weaviate.py
@@ -278,3 +278,15 @@ class WeaviateClient(Database):
         Insert or update the embeddings index in the database.
         """
         raise NotImplementedError("Weaviate does not support storing embeddings index.")
+
+    def search_by_id(
+        self,
+        ids: Union[List[str], List[int]],
+    ) -> List[Dict[str, Any]]:
+        """
+        Search embeddings by their IDs.
+        """
+        raise NotImplementedError(
+            "search_by_id is not implemented for Weaviate yet "
+            "because search by vector returns metadata already."
+        )


### PR DESCRIPTION
## Tickets

-

### What has been done

With this PR, we are returning img_name in faiss searches because faiss stores only index and this was missing in our pipeline.

## How to test

```shell
make lint && make test
```