### PR TITLE
raise error while attempting signed datastore without credentials

### DIFF
--- a/deepface/modules/recognition.py
+++ b/deepface/modules/recognition.py
@@ -805,9 +805,15 @@ def __verify_signature(
             This is going to be used to sign the integrity of the datastore pickle file.
             If not provided, the datastore will not be signed.
     """
+    signature_path = datastore_path + ".ldsa"
     if credentials is None:
-        logger.debug("No credentials provided. Skipping signature verification.")
-        return
+        if not os.path.exists(signature_path):
+            logger.debug("No credentials provided. Skipping signature verification.")
+            return
+        raise ValueError(
+            f"Credentials not provided but signature file {signature_path} exists."
+            "Cannot verify the datastore without credentials."
+        )
 
     dsa = __build_dsa(credentials=credentials)
 
@@ -816,7 +822,6 @@ def __verify_signature(
     with open(datastore_path, "rb") as f:
         data: bytes = f.read()
 
-    signature_path = datastore_path + ".ldsa"
     if not os.path.exists(signature_path):
         raise ValueError(
             f"Signature file {signature_path} not found."

--- a/tests/unit/test_signature.py
+++ b/tests/unit/test_signature.py
@@ -181,6 +181,23 @@ class TestSignature(unittest.TestCase):
             )
             self.__flush_datastore_and_signature()
 
+    def test_signed_datastore_with_no_credentials(self):
+        for algorithm_name in ALGORITHMS:
+            cs = LightDSA(algorithm_name=algorithm_name)
+
+            # this will create and sign the datastore
+            _ = DeepFace.find(img_path="dataset/img6.jpg", db_path=self.db_path, credentials=cs)
+
+            signature_path = f"{self.db_path}/{self.expected_ds}.ldsa"
+            with pytest.raises(
+                ValueError,
+                match=f"Credentials not provided but signature file {signature_path} exists.",
+            ):
+                _ = DeepFace.find(img_path="dataset/img7.jpg", db_path=self.db_path)
+
+            logger.info(f"✅ Signed datastore with no credentials test passed for {algorithm_name}")
+            self.__flush_datastore_and_signature()
+
     def test_custom_curves(self):
         for algorithm_name, form_name, curve_name in [
             # default configurations


### PR DESCRIPTION
## Tickets

-

### What has been done

With this PR, we will raise an error if an user attempts to load a signed datastore without credentials.

## How to test

```shell
make lint && make test
```