### PR TITLE
spoofing module class bug sorted

### DIFF
--- a/deepface/models/spoofing/FasNetBackbone.py
+++ b/deepface/models/spoofing/FasNetBackbone.py
@@ -3,7 +3,7 @@
 # Ref: github.com/minivision-ai/Silent-Face-Anti-Spoofing/blob/master/src/model_lib/MiniFASNet.py
 
 # built-in dependencies
-from typing import Tuple, Any, List, TYPE_CHECKING
+from typing import Tuple, Any, List
 
 # 3rd party dependencies
 import torch
@@ -17,15 +17,8 @@ from torch.nn import (
     Sigmoid,
     AdaptiveAvgPool2d,
     Sequential,
+    Module,
 )
-
-if TYPE_CHECKING:
-    from torch.nn import Module
-else:
-    # minimal stub for mypy
-    class Module:  # pylint: disable=too-few-public-methods
-        pass
-
 
 # pylint: disable=super-with-arguments, too-many-instance-attributes, unused-argument, redefined-builtin, too-few-public-methods
 


### PR DESCRIPTION
## Tickets

Resolves https://github.com/serengil/deepface/issues/1575

### What has been done

With this PR, spoofing module's FasNetBackbone.Depth_Wise is not a Module subclass bug sorted. We made this change in mypy switch.

## How to test

```shell
make lint && make test
```