### PR TITLE
Use readable query-string deepface.dev README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 <br>
 
 <div align="center">
-  <a href="https://deepface.dev/r/deepface-readme" target="_blank"><img src="https://img.shields.io/badge/Hosted-deepface.dev-00BFFF?style=flat&labelColor=555555" alt="Hosted | deepface.dev"/></a>
+  <a href="https://deepface.dev?source=deepface_repo" target="_blank"><img src="https://img.shields.io/badge/Hosted-deepface.dev-00BFFF?style=flat&labelColor=555555" alt="Hosted | deepface.dev"/></a>
 </div>
 
 </div>
@@ -63,7 +63,7 @@ Once you installed the library, then you will be able to import it and use its f
 from deepface import DeepFace
 ```
 
-> 💡 Prefer not to install or manage infrastructure? You can use a managed API via [deepface.dev](https://deepface.dev/r/deepface-readme).
+> 💡 Prefer not to install or manage infrastructure? You can use a managed API via [deepface.dev](https://deepface.dev?source=deepface_repo).
 
 **Face Verification** - [`Demo`](https://youtu.be/KRCvkNCOphE)
 
@@ -342,13 +342,13 @@ $ curl -X POST http://localhost:5005/search \
 
 [`Here`](https://github.com/serengil/deepface/tree/master/deepface/api/postman), you can find a postman project to find out how these methods should be called.
 
-**Hosted DeepFace** [![deepface.dev](https://img.shields.io/badge/-deepface.dev-00BFFF?style=flat&labelColor=0A0A0A&logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB3aWR0aD0iMjU2IiBoZWlnaHQ9IjI1NiIgdmlld0JveD0iMCAwIDI1NiAyNTYiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI%2BCiAgPHRpdGxlPmRlZXBmYWNlLmRldiBsb2dvPC90aXRsZT4KICA8cmVjdCB3aWR0aD0iMjU2IiBoZWlnaHQ9IjI1NiIgcng9IjI0IiBmaWxsPSIjMEEwQTBBIi8%2BCgogIDxkZWZzPgogICAgPGZpbHRlciBpZD0ibmVvbi1nbG93IiB4PSItNTAlIiB5PSItNTAlIiB3aWR0aD0iMjAwJSIgaGVpZ2h0PSIyMDAlIj4KICAgICAgPGZlR2F1c3NpYW5CbHVyIGluPSJTb3VyY2VHcmFwaGljIiBzdGREZXZpYXRpb249IjQiIHJlc3VsdD0iYmx1ciIgLz4KICAgICAgPGZlTWVyZ2U%2BCiAgICAgICAgPGZlTWVyZ2VOb2RlIGluPSJibHVyIiAvPgogICAgICAgIDxmZU1lcmdlTm9kZSBpbj0iU291cmNlR3JhcGhpYyIgLz4KICAgICAgPC9mZU1lcmdlPgogICAgPC9maWx0ZXI%2BCiAgPC9kZWZzPgoKICA8dGV4dCB4PSI1MCUiIHk9IjUwJSIKICAgICAgICBkb21pbmFudC1iYXNlbGluZT0ibWlkZGxlIgogICAgICAgIHRleHQtYW5jaG9yPSJtaWRkbGUiCiAgICAgICAgZmlsbD0iIzAwQkZGRiIKICAgICAgICBmb250LXNpemU9IjExMCIKICAgICAgICBmb250LXdlaWdodD0iNTAwIgogICAgICAgIGZvbnQtZmFtaWx5PSInRmlyYSBDb2RlJywgJ1JvYm90byBNb25vJywgdWktbW9ub3NwYWNlLCBTRk1vbm8tUmVndWxhciwgTWVubG8sIE1vbmFjbywgQ29uc29sYXMsICdMaWJlcmF0aW9uIE1vbm8nLCAnQ291cmllciBOZXcnLCBtb25vc3BhY2UiCiAgICAgICAgZmlsdGVyPSJ1cmwoI25lb24tZ2xvdykiPgogICAge2RmfQogIDwvdGV4dD4KPC9zdmc%2BCg%3D%3D)](https://deepface.dev/r/deepface-readme)
+**Hosted DeepFace** [![deepface.dev](https://img.shields.io/badge/-deepface.dev-00BFFF?style=flat&labelColor=0A0A0A&logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB3aWR0aD0iMjU2IiBoZWlnaHQ9IjI1NiIgdmlld0JveD0iMCAwIDI1NiAyNTYiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI%2BCiAgPHRpdGxlPmRlZXBmYWNlLmRldiBsb2dvPC90aXRsZT4KICA8cmVjdCB3aWR0aD0iMjU2IiBoZWlnaHQ9IjI1NiIgcng9IjI0IiBmaWxsPSIjMEEwQTBBIi8%2BCgogIDxkZWZzPgogICAgPGZpbHRlciBpZD0ibmVvbi1nbG93IiB4PSItNTAlIiB5PSItNTAlIiB3aWR0aD0iMjAwJSIgaGVpZ2h0PSIyMDAlIj4KICAgICAgPGZlR2F1c3NpYW5CbHVyIGluPSJTb3VyY2VHcmFwaGljIiBzdGREZXZpYXRpb249IjQiIHJlc3VsdD0iYmx1ciIgLz4KICAgICAgPGZlTWVyZ2U%2BCiAgICAgICAgPGZlTWVyZ2VOb2RlIGluPSJibHVyIiAvPgogICAgICAgIDxmZU1lcmdlTm9kZSBpbj0iU291cmNlR3JhcGhpYyIgLz4KICAgICAgPC9mZU1lcmdlPgogICAgPC9maWx0ZXI%2BCiAgPC9kZWZzPgoKICA8dGV4dCB4PSI1MCUiIHk9IjUwJSIKICAgICAgICBkb21pbmFudC1iYXNlbGluZT0ibWlkZGxlIgogICAgICAgIHRleHQtYW5jaG9yPSJtaWRkbGUiCiAgICAgICAgZmlsbD0iIzAwQkZGRiIKICAgICAgICBmb250LXNpemU9IjExMCIKICAgICAgICBmb250LXdlaWdodD0iNTAwIgogICAgICAgIGZvbnQtZmFtaWx5PSInRmlyYSBDb2RlJywgJ1JvYm90byBNb25vJywgdWktbW9ub3NwYWNlLCBTRk1vbm8tUmVndWxhciwgTWVubG8sIE1vbmFjbywgQ29uc29sYXMsICdMaWJlcmF0aW9uIE1vbm8nLCAnQ291cmllciBOZXcnLCBtb25vc3BhY2UiCiAgICAgICAgZmlsdGVyPSJ1cmwoI25lb24tZ2xvdykiPgogICAge2RmfQogIDwvdGV4dD4KPC9zdmc%2BCg%3D%3D)](https://deepface.dev?source=deepface_repo)
 
-Don’t want to host and scale DeepFace yourself? [`deepface.dev`](https://deepface.dev/r/deepface-readme)
+Don’t want to host and scale DeepFace yourself? [`deepface.dev`](https://deepface.dev?source=deepface_repo)
 provides a managed API built on top of DeepFace.
 
 - One API for verification, embeddings, and vector comparison
-- Docs and machine-readable agent docs: [`docs.deepface.dev`](https://deepface.dev/r/deepface-readme-docs)
+- Docs and machine-readable agent docs: [`docs.deepface.dev`](https://docs.deepface.dev?source=deepface_repo)
 - MCP endpoint: `https://deepface.dev/mcp` using a dedicated MCP key
 - Usage-based pricing that scales from testing to production
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 <br>
 
 <div align="center">
-  <a href="https://deepface.dev" target="_blank"><img src="https://img.shields.io/badge/Hosted-deepface.dev-00BFFF?style=flat&labelColor=555555" alt="Hosted | deepface.dev"/></a>
+  <a href="https://deepface.dev/r/deepface-readme" target="_blank"><img src="https://img.shields.io/badge/Hosted-deepface.dev-00BFFF?style=flat&labelColor=555555" alt="Hosted | deepface.dev"/></a>
 </div>
 
 </div>
@@ -63,7 +63,7 @@ Once you installed the library, then you will be able to import it and use its f
 from deepface import DeepFace
 ```
 
-> 💡 Prefer not to install or manage infrastructure? You can use a managed API via [deepface.dev](https://deepface.dev).
+> 💡 Prefer not to install or manage infrastructure? You can use a managed API via [deepface.dev](https://deepface.dev/r/deepface-readme).
 
 **Face Verification** - [`Demo`](https://youtu.be/KRCvkNCOphE)
 
@@ -342,13 +342,13 @@ $ curl -X POST http://localhost:5005/search \
 
 [`Here`](https://github.com/serengil/deepface/tree/master/deepface/api/postman), you can find a postman project to find out how these methods should be called.
 
-**Hosted DeepFace** [![deepface.dev](https://img.shields.io/badge/-deepface.dev-00BFFF?style=flat&labelColor=0A0A0A&logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB3aWR0aD0iMjU2IiBoZWlnaHQ9IjI1NiIgdmlld0JveD0iMCAwIDI1NiAyNTYiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI%2BCiAgPHRpdGxlPmRlZXBmYWNlLmRldiBsb2dvPC90aXRsZT4KICA8cmVjdCB3aWR0aD0iMjU2IiBoZWlnaHQ9IjI1NiIgcng9IjI0IiBmaWxsPSIjMEEwQTBBIi8%2BCgogIDxkZWZzPgogICAgPGZpbHRlciBpZD0ibmVvbi1nbG93IiB4PSItNTAlIiB5PSItNTAlIiB3aWR0aD0iMjAwJSIgaGVpZ2h0PSIyMDAlIj4KICAgICAgPGZlR2F1c3NpYW5CbHVyIGluPSJTb3VyY2VHcmFwaGljIiBzdGREZXZpYXRpb249IjQiIHJlc3VsdD0iYmx1ciIgLz4KICAgICAgPGZlTWVyZ2U%2BCiAgICAgICAgPGZlTWVyZ2VOb2RlIGluPSJibHVyIiAvPgogICAgICAgIDxmZU1lcmdlTm9kZSBpbj0iU291cmNlR3JhcGhpYyIgLz4KICAgICAgPC9mZU1lcmdlPgogICAgPC9maWx0ZXI%2BCiAgPC9kZWZzPgoKICA8dGV4dCB4PSI1MCUiIHk9IjUwJSIKICAgICAgICBkb21pbmFudC1iYXNlbGluZT0ibWlkZGxlIgogICAgICAgIHRleHQtYW5jaG9yPSJtaWRkbGUiCiAgICAgICAgZmlsbD0iIzAwQkZGRiIKICAgICAgICBmb250LXNpemU9IjExMCIKICAgICAgICBmb250LXdlaWdodD0iNTAwIgogICAgICAgIGZvbnQtZmFtaWx5PSInRmlyYSBDb2RlJywgJ1JvYm90byBNb25vJywgdWktbW9ub3NwYWNlLCBTRk1vbm8tUmVndWxhciwgTWVubG8sIE1vbmFjbywgQ29uc29sYXMsICdMaWJlcmF0aW9uIE1vbm8nLCAnQ291cmllciBOZXcnLCBtb25vc3BhY2UiCiAgICAgICAgZmlsdGVyPSJ1cmwoI25lb24tZ2xvdykiPgogICAge2RmfQogIDwvdGV4dD4KPC9zdmc%2BCg%3D%3D)](https://deepface.dev)
+**Hosted DeepFace** [![deepface.dev](https://img.shields.io/badge/-deepface.dev-00BFFF?style=flat&labelColor=0A0A0A&logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB3aWR0aD0iMjU2IiBoZWlnaHQ9IjI1NiIgdmlld0JveD0iMCAwIDI1NiAyNTYiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI%2BCiAgPHRpdGxlPmRlZXBmYWNlLmRldiBsb2dvPC90aXRsZT4KICA8cmVjdCB3aWR0aD0iMjU2IiBoZWlnaHQ9IjI1NiIgcng9IjI0IiBmaWxsPSIjMEEwQTBBIi8%2BCgogIDxkZWZzPgogICAgPGZpbHRlciBpZD0ibmVvbi1nbG93IiB4PSItNTAlIiB5PSItNTAlIiB3aWR0aD0iMjAwJSIgaGVpZ2h0PSIyMDAlIj4KICAgICAgPGZlR2F1c3NpYW5CbHVyIGluPSJTb3VyY2VHcmFwaGljIiBzdGREZXZpYXRpb249IjQiIHJlc3VsdD0iYmx1ciIgLz4KICAgICAgPGZlTWVyZ2U%2BCiAgICAgICAgPGZlTWVyZ2VOb2RlIGluPSJibHVyIiAvPgogICAgICAgIDxmZU1lcmdlTm9kZSBpbj0iU291cmNlR3JhcGhpYyIgLz4KICAgICAgPC9mZU1lcmdlPgogICAgPC9maWx0ZXI%2BCiAgPC9kZWZzPgoKICA8dGV4dCB4PSI1MCUiIHk9IjUwJSIKICAgICAgICBkb21pbmFudC1iYXNlbGluZT0ibWlkZGxlIgogICAgICAgIHRleHQtYW5jaG9yPSJtaWRkbGUiCiAgICAgICAgZmlsbD0iIzAwQkZGRiIKICAgICAgICBmb250LXNpemU9IjExMCIKICAgICAgICBmb250LXdlaWdodD0iNTAwIgogICAgICAgIGZvbnQtZmFtaWx5PSInRmlyYSBDb2RlJywgJ1JvYm90byBNb25vJywgdWktbW9ub3NwYWNlLCBTRk1vbm8tUmVndWxhciwgTWVubG8sIE1vbmFjbywgQ29uc29sYXMsICdMaWJlcmF0aW9uIE1vbm8nLCAnQ291cmllciBOZXcnLCBtb25vc3BhY2UiCiAgICAgICAgZmlsdGVyPSJ1cmwoI25lb24tZ2xvdykiPgogICAge2RmfQogIDwvdGV4dD4KPC9zdmc%2BCg%3D%3D)](https://deepface.dev/r/deepface-readme)
 
-Don’t want to host and scale DeepFace yourself? [`deepface.dev`](https://deepface.dev)
+Don’t want to host and scale DeepFace yourself? [`deepface.dev`](https://deepface.dev/r/deepface-readme)
 provides a managed API built on top of DeepFace.
 
 - One API for verification, embeddings, and vector comparison
-- Docs and machine-readable agent docs: [`docs.deepface.dev`](https://docs.deepface.dev)
+- Docs and machine-readable agent docs: [`docs.deepface.dev`](https://deepface.dev/r/deepface-readme-docs)
 - MCP endpoint: `https://deepface.dev/mcp` using a dedicated MCP key
 - Usage-based pricing that scales from testing to production
 


### PR DESCRIPTION
## What changed
- replace each README link target that was exactly `https://deepface.dev` with `https://deepface.dev?source=deepface_repo`
- replace the README docs link target `https://docs.deepface.dev` with `https://docs.deepface.dev?source=deepface_repo`
- keep visible README copy unchanged and leave the inline MCP endpoint text `https://deepface.dev/mcp` untouched

## Scope
- only `README.md` is changed
- no analytics, scripts, redirects, config, or non-README edits in this repo

## Why
- this follows the maintainer feedback to make the public links more human-readable
- the tracking behavior is preserved by a paired deepface.dev change in https://github.com/techlocal-accounts/deepface/pull/33, which routes these readable query URLs into the existing `/r/...` tracking flow

## Verification
- confirmed `git diff --name-only` returns only `README.md`
- reviewed the README diff to verify only the intended hosted-service link destinations changed
- docs-only change; no code paths or test suites were modified