### PR TITLE
heavy unit tests disabled

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,15 +1,18 @@
 name: Tests
 
 on: 
-  push:
-    paths:
-      - '.github/workflows/tests.yml'
-      - 'deepface/**'  
-      - 'tests/**'
-      - 'api/**'
-      - 'requirements.txt'
-      - '.gitignore'
-      - 'setup.py'
+  # i won't allow to push master directly, so this is not necessary
+  # push:
+  #   push:
+  #     branches:
+  #   paths:
+  #     - '.github/workflows/tests.yml'
+  #     - 'deepface/**'  
+  #     - 'tests/**'
+  #     - 'api/**'
+  #     - 'requirements.txt'
+  #     - '.gitignore'
+  #     - 'setup.py'
   pull_request:
     paths:
       - '.github/workflows/tests.yml'
@@ -83,5 +86,6 @@ jobs:
     - name: Test with pytest
       run: |
         cd tests/unit
-        python -m pytest . -s --disable-warnings
+        # python -m pytest . -s --disable-warnings
+        echo "Unit tests temporarily disabled in CI due to resource-intensive operations"
 


### PR DESCRIPTION
## Tickets

Resolves https://github.com/serengil/deepface/issues/1590
Resolves https://github.com/serengil/deepface/issues/1591

### What has been done

With this PR, we disabled heavy unit tests to avoid potential false-positive abuse/anomaly detection signals [1](https://x.com/serengil/status/2037250644709376507), [2](https://x.com/serengil/status/2040159778853335526)

## How to test

```shell
make lint && make test
```